### PR TITLE
chore(features): split code with more feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,26 +3,26 @@ name = "rust-device-detector"
 edition = "2021"
 
 [dependencies]
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.0", features = ["derive"], optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
-hyper = { version = "0.14", features = ["server", "tcp", "http1", "http2"] }
+hyper = { version = "0.14", features = ["server", "tcp", "http1", "http2"], optional = true }
 serde_yaml = "0.9"
 serde_json = "1.0"
 fancy-regex = "0.11"
 anyhow = "1.0"
 itertools = "0.11"
 once_cell = "1.8"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full"], optional = true }
 version-compare = "0.1.1"
 fallible-iterator = "0.3"
 moka = { version = "0.11", optional = true }
 const_format = "0.2"
 # dhat = "0.3.2"
-libc = "0.2"
+libc = {  version = "0.2", optional = true }
 
 [build-dependencies]
-cbindgen = "0.26"
+cbindgen = { version = "0.26", optional = true }
 
 [dev-dependencies]
 stats_alloc = "0.1.1"
@@ -35,12 +35,17 @@ test_each_file = { path = "test_each_file" }
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]
 
+[[bin]]
+name = "rust-device-detector"
+required-features = ["build-binary"]
 
 [features]
 default = []
 full = ["cache"]
 # cache is a feature because moka brings in a lot of dependencies.
 cache = ["dep:moka"]
+ffi = ["dep:libc", "dep:cbindgen"]
+build-binary = ["dep:clap", "dep:tokio", "dep:hyper"]
 
 [profile.test]
 # these tests take a long time without optimization

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
+#[cfg(feature = "ffi")]
 extern crate cbindgen;
-
+#[cfg(feature = "ffi")]
 use std::env;
 
 // TODO parse and optimize yaml files into serde binary for faster
@@ -13,10 +14,11 @@ fn main() {
 
     // let contents = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/regexes/bots.yml"));
     // let value: serde_yaml::Value = serde_yaml::from_str(contents).unwrap();
-
+    #[cfg(feature = "ffi")]
     build_cpp_header();
 }
 
+#[cfg(feature = "ffi")]
 fn build_cpp_header() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
 pub mod client_hints;
 pub mod device_detector;
+#[cfg(feature = "build-binary")]
 pub mod http;
 pub mod known_browsers;
 pub mod known_oss;
 pub mod parsers;
 
-// cfg(feature = "ffi")
+#[cfg(feature = "ffi")]
 pub mod ffi;


### PR DESCRIPTION
This reduce dependencies on the library part, so when only using this crate as a dependency / library it reduces from 140~ deps to 48~

However the best option here would be to split this crate into multiples one, like 

 * one crate for only the library
 * one crate for the binary
 * one crate for the ffi linking (but it can still be done with a feature in the lib, make sense also)