### PR TITLE
Allow to use a shared cache between multiple instance of DeviceDetector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,47 +147,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
-name = "bytecount"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
-
-[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
-
-[[package]]
-name = "camino"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "cbindgen"
@@ -383,15 +346,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -739,15 +693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "mach2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.11.3"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6e72583bf6830c956235bff0d5afec8cf2952f579ebad18ae7821a917d950f"
+checksum = "32cf62eb4dd975d2dde76432fb1075c49e3ee2331cf36f1f8fd4b66550d32b6f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -795,8 +740,6 @@ dependencies = [
  "parking_lot",
  "quanta",
  "rustc_version",
- "scheduled-thread-pool",
- "skeptic",
  "smallvec",
  "tagptr",
  "thiserror",
@@ -886,25 +829,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
-dependencies = [
- "bitflags 1.3.2",
- "memchr",
- "unicase",
-]
-
-[[package]]
 name = "quanta"
-version = "0.11.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
 dependencies = [
  "crossbeam-utils",
  "libc",
- "mach2",
  "once_cell",
  "raw-cpuid",
  "wasi",
@@ -923,11 +854,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.7.0"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
 ]
 
 [[package]]
@@ -1018,24 +949,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,9 +959,6 @@ name = "semver"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
@@ -1101,21 +1011,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
 ]
 
 [[package]]
@@ -1345,15 +1240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,22 +1277,6 @@ name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "walkdir"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.69",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +377,27 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -733,9 +785,13 @@ version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cf62eb4dd975d2dde76432fb1075c49e3ee2331cf36f1f8fd4b66550d32b6f"
 dependencies = [
+ "async-lock",
+ "async-trait",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "event-listener",
+ "futures-util",
  "once_cell",
  "parking_lot",
  "quanta",
@@ -777,6 +833,12 @@ name = "os_str_bytes"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -94,13 +94,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "531b97fb4cd3dfdce92c35dedbfdc1f0b9d8091c8ca943d6dae340ef5012d514"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -366,7 +366,7 @@ checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
@@ -678,9 +678,9 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.9",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "linux-raw-sys"
@@ -770,13 +770,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -801,16 +802,6 @@ dependencies = [
  "thiserror",
  "triomphe",
  "uuid",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.2",
- "libc",
 ]
 
 [[package]]
@@ -860,7 +851,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1001,7 +992,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1102,12 +1093,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1160,7 +1151,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1212,28 +1203,27 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.7",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1456,7 +1446,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1465,13 +1464,29 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1481,10 +1496,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1493,10 +1520,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1505,13 +1550,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "attribute-derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c124f12ade4e670107b132722d0ad1a5c9790bcbc1b265336369ea05626b4498"
+dependencies = [
+ "attribute-derive-macro",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b217a07446e0fb086f83401a98297e2d81492122f5874db5391bd270a185f88"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "proc-macro-error",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "collection_literals"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +378,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -519,6 +564,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "get-size"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b61e2dab7eedce93a83ab3468b919873ff16bac5a3e704011ff836d22b2120"
+dependencies = [
+ "get-size-derive",
+]
+
+[[package]]
+name = "get-size-derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a1bcfb855c1f340d5913ab542e36f25a1c56f57de79022928297632435dec2"
+dependencies = [
+ "attribute-derive",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +657,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "http"
@@ -673,14 +744,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
+name = "interpolator"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.9",
- "rustix",
- "windows-sys 0.48.0",
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -873,6 +950,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1015,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "quote-use"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b5abe3fe82fdeeb93f44d66a7b444dedf2e4827defb0a8e69c437b2de2ef94"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ea44c7e20f16017a76a245bb42188517e13d16dcb1aa18044bc406cdc3f4af"
+dependencies = [
+ "derive-where",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -951,6 +1086,7 @@ dependencies = [
  "fallible-iterator",
  "fancy-regex",
  "futures",
+ "get-size",
  "glob",
  "hyper",
  "indexmap 2.0.0",
@@ -1329,6 +1465,12 @@ name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 clap = { version = "4.0", features = ["derive"], optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
+get-size = { version = "0.1.4", features = ["derive"] }
 hyper = { version = "0.14", features = ["server", "tcp", "http1", "http2"], optional = true }
 serde_yaml = "0.9"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ once_cell = "1.8"
 tokio = { version = "1", features = ["full"], optional = true }
 version-compare = "0.2.0"
 fallible-iterator = "0.3"
-moka = { version = "0.12.8", optional = true }
+moka = { version = "0.12.8", features = ["future"], optional = true }
 const_format = "0.2"
 # dhat = "0.3.2"
 libc = {  version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ once_cell = "1.8"
 tokio = { version = "1", features = ["full"], optional = true }
 version-compare = "0.2.0"
 fallible-iterator = "0.3"
-moka = { version = "0.11", optional = true }
+moka = { version = "0.12.8", optional = true }
 const_format = "0.2"
 # dhat = "0.3.2"
 libc = {  version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ cbindgen = { version = "0.26", optional = true }
 stats_alloc = "0.1.1"
 futures = "0.3"
 glob = "0.3"
+tokio = { version = "1.38.0", features = ["test-util", "macros"] }
 
 # proc macro to iterate over yml files in tests, has to be own crate.
 test_each_file = { path = "test_each_file" }

--- a/src/device_detector.rs
+++ b/src/device_detector.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 #[cfg(feature = "cache")]
 use std::sync::Arc;
-
+use get_size::GetSize;
 use serde::Serialize;
 
 use crate::client_hints::ClientHint;
@@ -16,13 +16,13 @@ pub use bot::Bot;
 
 // TODO we should Box KnownDevice as it is much larger than Bot
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, GetSize)]
 pub enum Detection {
     Known(KnownDevice),
     Bot(Bot),
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, GetSize)]
 pub struct KnownDevice {
     pub client: Option<client::Client>,
     pub device: Option<device::Device>,

--- a/src/device_detector.rs
+++ b/src/device_detector.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+#[cfg(feature = "cache")]
+use std::sync::Arc;
 
 use serde::Serialize;
 
@@ -540,14 +542,12 @@ impl KnownDevice {
 // use std::alloc::System;
 
 #[cfg(feature = "cache")]
-type DetectionCache = Cache<String, Detection>;
+type DetectionCache = Arc<Cache<String, Detection>>;
 
 #[derive(Clone)]
 pub struct DeviceDetector {
     #[cfg(feature = "cache")]
-    caching: bool,
-    #[cfg(feature = "cache")]
-    cache: DetectionCache,
+    cache: Option<DetectionCache>,
 }
 
 impl DeviceDetector {
@@ -560,20 +560,18 @@ impl DeviceDetector {
     #[cfg(feature = "cache")]
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        Self {
-            caching: false,
-            cache: Cache::new(0),
-        }
+        Self { cache: None }
     }
 
     #[cfg(feature = "cache")]
-    pub fn new_with_cache(entries: u64) -> Self {
-        Self {
-            caching: true,
-            cache: Cache::new(entries),
-        }
+    pub fn new_with_cache(cache: DetectionCache) -> Self {
+        Self { cache: Some(cache) }
     }
-    pub async fn parse(&self, ua: &str, headers: Option<Vec<(String, String)>>) -> Result<Detection> {
+    pub async fn parse(
+        &self,
+        ua: &str,
+        headers: Option<Vec<(String, String)>>,
+    ) -> Result<Detection> {
         let client_hints = match headers {
             Some(headers) => Some(ClientHint::from_headers(headers)?),
             None => None,
@@ -604,19 +602,23 @@ impl DeviceDetector {
 
         #[cfg(feature = "cache")]
         {
-            if !self.caching {
-                return Ok(parse()?);
+            match &self.cache {
+                Some(cache) => {
+                    let result = cache.get(ua).await;
+
+                    match result {
+                        Some(res) => return Ok(res),
+                        None => {
+                            let known = parse()?;
+
+                            cache.insert(ua.to_owned(), known.clone()).await;
+
+                            Ok(known)
+                        }
+                    }
+                }
+                None => Ok(parse()?),
             }
-
-            if let Some(res) = self.cache.get(ua).await {
-                return Ok(res);
-            };
-
-            let known = parse()?;
-
-            self.cache.insert(ua.to_owned(), known.clone()).await;
-
-            Ok(known)
         }
 
         #[cfg(not(feature = "cache"))]

--- a/src/known_browsers.rs
+++ b/src/known_browsers.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-
+use get_size::GetSize;
 use serde::Serialize;
 
 // These are the known browsers from matamo's device detector. While this
@@ -12,7 +12,7 @@ pub struct AvailableBrowsers {
     browsers_by_name: HashMap<String, AvailableBrowser>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, GetSize)]
 pub struct AvailableBrowser {
     pub name: String,
     pub family: Option<String>,

--- a/src/known_oss.rs
+++ b/src/known_oss.rs
@@ -302,7 +302,10 @@ fn os_families() -> HashMap<String, Vec<String>> {
         ),
         ("WebTV", vec!["WTV"]),
         ("Windows", vec!["WIN"]),
-        ("Windows Mobile", vec!["WPH", "WMO", "WCE", "WRT", "WIO", "KIN"]),
+        (
+            "Windows Mobile",
+            vec!["WPH", "WMO", "WCE", "WRT", "WIO", "KIN"],
+        ),
         ("Other Smart TV", vec!["WHS"]),
     ]
     .into_iter()

--- a/src/parsers/bot.rs
+++ b/src/parsers/bot.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-
+use get_size::GetSize;
 use serde::Deserialize;
 
 use once_cell::sync::Lazy;
@@ -16,7 +16,7 @@ pub fn lookup_bot(ua: &str) -> Result<Option<Bot>> {
     BOT_LIST.lookup(ua)
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, GetSize)]
 pub struct Bot {
     pub name: String,
     pub category: Option<String>,
@@ -24,7 +24,7 @@ pub struct Bot {
     pub producer: Option<BotProducer>,
 }
 
-#[derive(Debug, Deserialize, Clone, Serialize)]
+#[derive(Debug, Deserialize, Clone, Serialize, GetSize)]
 pub struct BotProducer {
     pub name: Option<String>,
     pub url: Option<String>,

--- a/src/parsers/client.rs
+++ b/src/parsers/client.rs
@@ -18,7 +18,7 @@
 //
 
 use anyhow::Result;
-
+use get_size::GetSize;
 use serde::{Deserialize, Serialize};
 
 use serde::de::Deserializer;
@@ -37,7 +37,7 @@ pub mod pim;
 use crate::client_hints::ClientHint;
 
 #[repr(C)]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, GetSize)]
 pub enum ClientType {
     #[serde(rename = "browser")]
     Browser,
@@ -66,7 +66,7 @@ impl ClientType {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, GetSize)]
 pub struct Client {
     pub name: String,
     pub version: Option<String>,

--- a/src/parsers/device.rs
+++ b/src/parsers/device.rs
@@ -11,7 +11,7 @@ use version_compare::{self, Version};
 use super::vendor_fragments;
 
 use std::borrow::Cow;
-
+use get_size::GetSize;
 use crate::client_hints::ClientHint;
 use crate::parsers::client::{Client, ClientType};
 use crate::parsers::oss::OS;
@@ -29,7 +29,7 @@ pub mod portable_media_players;
 pub mod shell_tvs;
 pub mod televisions;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, GetSize)]
 pub enum DeviceType {
     #[serde(rename = "desktop")]
     Desktop,
@@ -108,7 +108,7 @@ impl DeviceType {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, GetSize)]
 pub struct Device {
     #[serde(rename = "type")]
     pub device_type: Option<DeviceType>,

--- a/src/parsers/oss.rs
+++ b/src/parsers/oss.rs
@@ -6,7 +6,7 @@ use serde_yaml::Value;
 use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
-
+use get_size::GetSize;
 use crate::client_hints::ClientHint;
 use crate::known_oss::AvailableOSs;
 use crate::parsers::utils::{
@@ -75,7 +75,7 @@ static LINEAGE_OS_VERSION: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     .collect::<HashMap<_, _>>()
 });
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, GetSize)]
 pub struct OS {
     pub name: String,
     pub version: Option<String>,

--- a/test_each_file/src/lib.rs
+++ b/test_each_file/src/lib.rs
@@ -119,9 +119,9 @@ fn generate_from_tree(tree: &Paths, parsed: &ForEachFile, stream: &mut TokenStre
         };
 
         stream.extend(quote! {
-            #[test]
-            fn #file_name() {
-                (#function)(#file_name_str, #content)
+            #[tokio::test]
+            async fn #file_name() {
+                (#function)(#file_name_str, #content).await
             }
         });
     }

--- a/tests/php_tests/bots.rs
+++ b/tests/php_tests/bots.rs
@@ -3,11 +3,11 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-pub(crate) fn basic(idx: usize, value: &Value) -> Result<()> {
+pub(crate) async fn basic(idx: usize, value: &Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_bot = value["bot"].as_mapping().expect("bot");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     assert!(
         dd_res.is_bot(),

--- a/tests/php_tests/parser/client/browsers.rs
+++ b/tests/php_tests/parser/client/browsers.rs
@@ -7,8 +7,8 @@ use std::io::BufReader;
 
 use rust_device_detector::client_hints::ClientHint;
 
-#[test]
-fn test_parser_browsers() -> Result<()> {
+#[tokio::test]
+async fn test_parser_browsers() -> Result<()> {
     let files: Vec<BufReader<File>> = vec![BufReader::new(
         File::open("tests/data/fixtures/parser/client/browser.yml").expect("file"),
     )];
@@ -20,14 +20,14 @@ fn test_parser_browsers() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_client = value["client"].as_mapping().expect("client");
     let dd = &utils::DD;
@@ -37,7 +37,7 @@ fn basic(idx: usize, value: &mut Value) -> Result<()> {
         .and_then(|headers| headers.as_mapping())
         .and_then(|headers| utils::client_hint_mock(headers).ok());
 
-    let dd_res = dd.parse_client_hints(ua, client_hints)?;
+    let dd_res = dd.parse_client_hints(ua, client_hints).await?;
 
     assert!(!dd_res.is_bot());
 

--- a/tests/php_tests/parser/client/feed_reader.rs
+++ b/tests/php_tests/parser/client/feed_reader.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_parser_feed_readers() -> Result<()> {
+#[tokio::test]
+async fn test_parser_feed_readers() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/client/feed_reader.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,18 +14,18 @@ fn test_parser_feed_readers() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_client = value["client"].as_mapping().expect("client");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     assert!(!dd_res.is_bot());
 

--- a/tests/php_tests/parser/client/library.rs
+++ b/tests/php_tests/parser/client/library.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_parser_libraries() -> Result<()> {
+#[tokio::test]
+async fn test_parser_libraries() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/client/library.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,18 +14,18 @@ fn test_parser_libraries() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_client = value["client"].as_mapping().expect("client");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     assert!(!dd_res.is_bot());
 

--- a/tests/php_tests/parser/client/mediaplayers.rs
+++ b/tests/php_tests/parser/client/mediaplayers.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_parser_mediaplayers() -> Result<()> {
+#[tokio::test]
+async fn test_parser_mediaplayers() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/client/mediaplayer.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,18 +14,18 @@ fn test_parser_mediaplayers() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_client = value["client"].as_mapping().expect("client");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     assert!(!dd_res.is_bot());
 

--- a/tests/php_tests/parser/client/mobile_apps.rs
+++ b/tests/php_tests/parser/client/mobile_apps.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_parser_mobile_apps() -> Result<()> {
+#[tokio::test]
+async fn test_parser_mobile_apps() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/client/mobile_app.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,18 +14,18 @@ fn test_parser_mobile_apps() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_client = value["client"].as_mapping().expect("client");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     assert!(
         !dd_res.is_bot(),

--- a/tests/php_tests/parser/client/pim.rs
+++ b/tests/php_tests/parser/client/pim.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_parser_pims() -> Result<()> {
+#[tokio::test]
+async fn test_parser_pims() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/client/pim.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,18 +14,18 @@ fn test_parser_pims() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_client = value["client"].as_mapping().expect("client");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     assert!(!dd_res.is_bot());
 

--- a/tests/php_tests/parser/device/camera.rs
+++ b/tests/php_tests/parser/device/camera.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_parser_cameras() -> Result<()> {
+#[tokio::test]
+async fn test_parser_cameras() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/device/camera.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,18 +14,18 @@ fn test_parser_cameras() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_device = value["device"].as_mapping().expect("device");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     assert!(!dd_res.is_bot(), "expected not bot");
 

--- a/tests/php_tests/parser/device/car_browser.rs
+++ b/tests/php_tests/parser/device/car_browser.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_parser_car_browsers() -> Result<()> {
+#[tokio::test]
+async fn test_parser_car_browsers() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/device/car_browser.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,18 +14,18 @@ fn test_parser_car_browsers() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_device = value["device"].as_mapping().expect("device");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     assert!(!dd_res.is_bot(), "expected not bot");
 

--- a/tests/php_tests/parser/device/console.rs
+++ b/tests/php_tests/parser/device/console.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_parser_consoles() -> Result<()> {
+#[tokio::test]
+async fn test_parser_consoles() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/device/console.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,18 +14,18 @@ fn test_parser_consoles() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_device = value["device"].as_mapping().expect("device");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     assert!(!dd_res.is_bot(), "expected not bot");
 

--- a/tests/php_tests/parser/device/notebook.rs
+++ b/tests/php_tests/parser/device/notebook.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_parser_notebooks() -> Result<()> {
+#[tokio::test]
+async fn test_parser_notebooks() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/device/notebook.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,18 +14,18 @@ fn test_parser_notebooks() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_device = value["device"].as_mapping().expect("device");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     assert!(!dd_res.is_bot(), "expected not bot");
 

--- a/tests/php_tests/parser/oss.rs
+++ b/tests/php_tests/parser/oss.rs
@@ -4,8 +4,8 @@ use serde_yaml::Value;
 use crate::utils;
 use rust_device_detector::client_hints::ClientHint;
 
-#[test]
-fn test_oss() -> Result<()> {
+#[tokio::test]
+async fn test_oss() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/oss.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -15,14 +15,14 @@ fn test_oss() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_os = value["os"].as_mapping().expect("os");
     let dd = &utils::DD;
@@ -32,7 +32,7 @@ fn basic(idx: usize, value: &mut Value) -> Result<()> {
         .and_then(|headers| headers.as_mapping())
         .and_then(|headers| utils::client_hint_mock(headers).ok());
 
-    let dd_res = dd.parse_client_hints(ua, client_hints)?;
+    let dd_res = dd.parse_client_hints(ua, client_hints).await?;
 
     assert!(!dd_res.is_bot());
 

--- a/tests/php_tests/parser/type_methods.rs
+++ b/tests/php_tests/parser/type_methods.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_type_methods() -> Result<()> {
+#[tokio::test]
+async fn test_type_methods() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/type-methods.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,19 +14,19 @@ fn test_type_methods() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["user_agent"].as_str().expect("user_agent");
     let test_checks = value["check"].as_sequence().expect("checks");
 
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     let test_bot = test_checks[0].as_bool().expect("bot");
     let dd_bot = dd_res.is_bot();

--- a/tests/php_tests/parser/vendorfragments.rs
+++ b/tests/php_tests/parser/vendorfragments.rs
@@ -3,8 +3,8 @@ use serde_yaml::Value;
 
 use crate::utils;
 
-#[test]
-fn test_vendorfragments() -> Result<()> {
+#[tokio::test]
+async fn test_vendorfragments() -> Result<()> {
     let files = utils::files("tests/data/fixtures/parser/vendorfragments.yml")?;
 
     assert!(!files.is_empty(), "expected at least one file");
@@ -14,18 +14,18 @@ fn test_vendorfragments() -> Result<()> {
         let cases = cases.as_sequence_mut().expect("sequence");
 
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            basic(i + 1, case).await.expect("basic test");
         }
     }
 
     Ok(())
 }
 
-fn basic(idx: usize, value: &mut Value) -> Result<()> {
+async fn basic(idx: usize, value: &mut Value) -> Result<()> {
     let ua = value["useragent"].as_str().expect("user_agent");
     let test_vendor = value["vendor"].as_str().expect("vendor");
     let dd = &utils::DD;
-    let dd_res = dd.parse(ua, None)?;
+    let dd_res = dd.parse(ua, None).await?;
 
     let dd_brand: &str = dd_res
         .get_known_device()


### PR DESCRIPTION
Not sure you want this, but we have done this in our fork to match our behavior.

We mainly use this library in a binary on our server that read logs from a message queue and parse them, including device detection using this library.

We have multiple threads running it to parallelize the process of logs parsing, and since this library consume most of the cpu (no blaming here, i totally understand why it's slow, but it's a fact). we use a specific device detector in each thread (so other threads are not blocked by it).

In order to avoid having a specific cache for each thread we added this code, so even if we have multiple instance of device detector they all use the same cache and it avoid consuming too much memory for the same data.

We also added get_size library that allows to correctly guess the size of a cache structure for moka, and then correctly set limit for our cache in terms of memory and not in terms of items