### PR TITLE
Improve iOS 26 and several OS detection

### DIFF
--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -6,6 +6,76 @@
 ###############
 
 ##########
+# NuttX (https://nuttx.apache.org/)
+##########
+- regex: 'NuttX(?:/(\d+[.\d]+))?'
+  name: 'NuttX'
+  version: '$1'
+
+##########
+# Contiki (https://www.contiki-os.org/ | https://github.com/contiki-os/contiki)
+##########
+- regex: 'Contiki/(\d+[.\d]+)'
+  name: 'Contiki'
+  version: '$1'
+
+##########
+# MINIX (https://www.minix3.org/)
+##########
+- regex: 'Minix (\d+[.\d]+)'
+  name: 'MINIX'
+  version: '$1'
+
+##########
+# Plan 9 (https://9p.io/plan9/)
+##########
+- regex: 'Plan 9 (\d+[.\d]+)'
+  name: 'Plan 9'
+  version: '$1'
+
+##########
+# Linpus (https://www.linpus.com/)
+##########
+- regex: 'Linpus/(\d+[.\d]+)'
+  name: 'Linpus'
+  version: '$1'
+
+##########
+# ArcaOS (https://www.arcanoae.com/)
+##########
+- regex: 'ArcaOS(?: (\d+[.\d]+))?'
+  name: 'ArcaOS'
+  version: '$1'
+
+##########
+# GhostBSD (https://www.ghostbsd.org/)
+##########
+- regex: 'GhostBSD/(\d+[.\d]+)'
+  name: 'GhostBSD'
+  version: '$1'
+
+##########
+# elementary OS (https://elementary.io/)
+##########
+- regex: 'elementary OS/(\d+[.\d]+)'
+  name: 'elementary OS'
+  version: '$1'
+
+##########
+# Mocor OS
+##########
+- regex: 'SpreadTrum'
+  name: 'Mocor OS'
+  version: ''
+
+##########
+# Titan OS (https://www.titanos.tv/)
+##########
+- regex: 'TitanOS/(\d+[.\d]+)'
+  name: 'Titan OS'
+  version: '$1'
+
+##########
 # KolibriOS (https://www.kolibrios.org/en/)
 ##########
 - regex: 'KolibriOS'
@@ -115,7 +185,7 @@
 ##########
 # OpenVMS (https://vmssoftware.com/)
 ##########
-- regex: 'OpenVMS V(\d+[.\d]+)'
+- regex: 'OpenVMS(?: V(\d+[.\d]+))?'
   name: 'OpenVMS'
   version: '$1'
 
@@ -514,6 +584,13 @@
   version: ''
 
 ##########
+# Orsay (https://news.samsung.com/global/interview-transition-to-tizen-how-a-talented-team-of-developers-laid-the-foundation-for-ai-tv)
+##########
+- regex: 'SmartHub; ?SMART-TV|HbbTV/.+Maple|Samsung;SmartTV201[2-5]'
+  name: 'Orsay'
+  version: ''
+
+##########
 # Tizen (https://www.tizen.org/)
 ##########
 - regex: 'Tizen[ /]?(\d+[.\d]+)?'
@@ -583,6 +660,10 @@
 ##########
 # Custom Android Roms
 ##########
+- regex: 'OpenHarmony(?:[/ ](\d+[.\d]+))?'
+  name: 'OpenHarmony'
+  version: '$1'
+
 - regex: 'HarmonyOS(?:[/ ](\d+[.\d]+))?'
   name: 'HarmonyOS'
   version: '$1'
@@ -606,6 +687,33 @@
   name: 'MocorDroid'
   version: '$1'
 
+##########
+# Smartisan OS (https://www.smartisan.com/os/)
+##########
+- regex: 'Smartisan[_ ]|(SM(?:70[15]|801|919)|YQ60[1357]|DT2002C|DE106|DT190[12]A|O[CE]106|OC105)[ /;\)]'
+  name: 'Smartisan OS'
+  versions:
+    - regex: 'SM70[15]'
+      version: '1.5'
+    - regex: 'SM801'
+      version: '2.5'
+    - regex: 'SM919'
+      version: '3.0'
+    - regex: 'YQ60[1357]'
+      version: '2.0'
+    - regex: 'DE106[ /;\)]'
+      version: '6.0'
+    - regex: 'OE106[ /;\)]'
+      version: '6.0'
+    - regex: 'OC10[56][ /;\)]'
+      version: '6.0'
+    - regex: 'DT2002C[ /;\)]'
+      version: '6.0'
+    - regex: 'DT190[12]A[ /;\)]'
+      version: '6.0'
+    - regex: 'Smartisan U3 Pro'
+      version: '3.0'
+
 - regex: 'FydeOS'
   name: 'FydeOS'
   version: ''
@@ -613,11 +721,11 @@
 ##########
 # Fire OS (https://developer.amazon.com/docs/fire-tv/fire-os-overview.html)
 ##########
-- regex: 'Fire OS(?:/(\d+[.\d]*))?'
+- regex: 'Fire OS(?:[ /](\d+[.\d]*))?'
   name: 'Fire OS'
   version: '$1'
 
-- regex: '(?:Andr[o0]id (\d([\d.])*);? |Amazon;|smarttv_)AFT|AEO[ACBHKT]|KF[ADFGJKMORSTQ]|.*FIRETVSTICK2018'
+- regex: '(?:Andr[o0]id (\d([\d.])*);? |Amazon;|smarttv_)AFT|AEO[ACBHKT]| KF[ADFGJKMORSTQ]|.+FIRETVSTICK2018'
   name: 'Fire OS'
   versions:
     - regex: 'Andr[o0]id 1[01].+ (?:AFT|KF[ADFGJKMORSTQ])'
@@ -845,11 +953,19 @@
   name: 'Android'
   version: '$1'
 
+- regex: 'Android;(\d+[.\d]*);API'
+  name: 'Android'
+  version: '$1'
+
+- regex: 'Android \(\d{2}/(\d+[.\d]*);'
+  name: 'Android'
+  version: '$1'
+
 - regex: '[ ]([\d.]+)\) AppleWebKit.*ROBLOX Android App'
   name: 'Android'
   version: '$1'
 
-- regex: '(?:(?:Orca-)?(?<!like |/|RadioPublic |Anghami |Callpod Keeper for )Android|Adr|AOSP)[ /]?(?:[a-z]+ )?(\d+[.\d]*)'
+- regex: '(?:(?:Orca-)?(?<!like |/|RadioPublic |Anghami |Callpod Keeper for |com\.linkedin\.)Android|Adr|AOSP)[ /]?(?:[a-z]+ )?(\d+[.\d]*)'
   name: 'Android'
   version: '$1'
 
@@ -935,6 +1051,14 @@
 - regex: 'MRE/(\d+)\.(\d+).*;MAUI'
   name: 'MRE'
   version: '$1.$2'
+
+- regex: 'MRE\\\\(\d+[.\d]+)'
+  name: 'MRE'
+  version: '$1'
+
+- regex: '.+MRE|MAUI Runtime'
+  name: 'MRE'
+  version: ''
 
 ##########
 # Linux
@@ -1050,7 +1174,7 @@
   name: 'SUSE'
   version: '$1'
 
-- regex: '(?:rhel|Red Hat Enterprise Linux Server)/(\d+[.\d]+)'
+- regex: '(?:rhel|Red ?Hat(?: Enterprise)? Linux(?: Server)?)[ /](\d+[.\d]+)'
   name: 'Red Hat'
   version: '$1'
 
@@ -1126,9 +1250,13 @@
   name: 'Deepin'
   version: '$1'
 
-- regex: '(Debian|Knoppix|Mint(?! Browser)|Ubuntu|Kubuntu|Xubuntu|Lubuntu|Fedora|Red Hat|Mandriva|Gentoo|Sabayon|Slackware|SUSE|CentOS|BackTrack|Freebox|ASPLinux)(?:(?: Enterprise)? Linux)?(?:[ /\-](\d+[.\d]+))?'
+- regex: '(Debian|Knoppix|Mint(?! Browser)|Ubuntu|Kubuntu|Xubuntu|Lubuntu|Fedora|Red Hat|Mandriva|Gentoo|Sabayon|Slackware|openSUSE|SUSE|CentOS|BackTrack|Freebox|ASPLinux)(?:(?: Enterprise)? Linux)?(?:[ /\-](\d+[.\d]+))?'
   name: '$1'
   version: '$2'
+
+- regex: '.+gentoo'
+  name: 'Gentoo'
+  version: ''
 
 - regex: 'OS ROSA; Linux'
   name: 'Rosa'
@@ -1143,6 +1271,8 @@
   versions:
     - regex: 'WEBOS(\d+[.\d]+)'
       version: '$1'
+    - regex: 'Web0S; Linux/SmartTV.+Chr[o0]me/120'
+      version: '25'
     - regex: 'Web0S; Linux/SmartTV.+Chr[o0]me/108'
       version: '24'
     - regex: 'Web0S; Linux/SmartTV.+Chr[o0]me/94'
@@ -1326,31 +1456,31 @@
 ##########
 # iPadOS (https://www.apple.com/ipados/)
 ##########
-- regex: 'FBMD/iPad;.*FBSV/ ?(1[3-8]|26).(\d+[.\d]*);'
+- regex: 'FBMD/iPad;.*FBSV/ ?(1[3-9]|26).(\d+[.\d]*);'
   name: 'iPadOS'
   version: '$1.$2'
 
-- regex: 'iPad(?:OS)?[ /](1[3-8]|26)\.(\d+[.\d]*)'
+- regex: 'iPad(?:OS)?[ /](1[3-9]|26)\.(\d+[.\d]*)'
   name: 'iPadOS'
   version: '$1.$2'
 
-- regex: '^iPad(?:\d+[\,\d]*)/(1[3-8]|26)\.(\d+[.\d]*)'
+- regex: '^iPad(?:\d+[\,\d]*)/(1[3-9]|26)\.(\d+[.\d]*)'
   name: 'iPadOS'
   version: '$1.$2'
 
-- regex: 'iPad(?:; (?:iOS|iPadOS|iPhone OS)|.+CPU (?:iPad |iPhone )?OS) ((1[3-8]|26)+(?:[_.]\d+)*)'
+- regex: 'iPad(?:; (?:iOS|iPadOS|iPhone OS)|.+CPU (?:iPad |iPhone )?OS) ((1[3-9]|26)+(?:[_.]\d+)*)'
   name: 'iPadOS'
   version: '$1'
 
-- regex: 'iOS/(1[3-8]|26)\.(\d+[.\d]*).+Apple/iPad'
+- regex: 'iOS[ /](1[3-9]|26)\.(\d+[.\d]*).+iPad'
   name: 'iPadOS'
   version: '$1.$2'
 
-- regex: 'iPhone OS,(1[3-8]|26)\.(\d+[.\d]*).+iPad'
+- regex: 'iPhone OS,(1[3-9]|26)\.(\d+[.\d]*).+iPad'
   name: 'iPadOS'
   version: '$1.$2'
 
-- regex: 'iphoneos(1[3-8]|26)\.(\d+[.\d]*); iPad'
+- regex: 'iphoneos(1[3-9]|26)\.(\d+[.\d]*); iPad'
   name: 'iPadOS'
   version: '$1.$2'
 
@@ -1369,7 +1499,7 @@
   name: 'iOS'
   version: '$1'
 
-- regex: 'iphoneos(1[3-8]|26)\.(\d+[.\d]*); iPhone'
+- regex: 'iphoneos(1[3-9]|26)\.(\d+[.\d]*); iPhone'
   name: 'iOS'
   version: '$1.$2'
 
@@ -1385,6 +1515,18 @@
   name: 'iOS'
   version: '$1.$2.$3'
 
+- regex: '(?:CPU OS|iPh(?:one)?[ _]OS|iPhone.+ OS|PodMN.+iPhone|iOS)[ _/]19(?:[_.])?(\d+(?:[._]\d+)*)'
+  name: 'iOS'
+  version: '26.$1'
+
+- regex: 'iPhone OS 18_7.+Version/(\d+[.\d]+)'
+  name: 'iOS'
+  version: '$1'
+
+- regex: 'iOS/(\d+[.\d]+)$'
+  name: 'iOS'
+  version: '$1'
+
 - regex: '(?:CPU OS|iPh(?:one)?[ _]OS|iPhone.+ OS|PodMN.+iPhone|iOS)[ _/](\d+(?:[_.]\d+)*)'
   name: 'iOS'
   version: '$1'
@@ -1393,11 +1535,21 @@
   name: 'iOS'
   version: '$1'
 
-- regex: '^(?!com\.apple\.Safari\.SearchHelper|Safari|NetworkingExtension).*(?:CFNetwork|Mana)/.+ Darwin/(\d+[.\d]+)(?!.*(?:x86_64|i386|PowerMac|Power%20Macintosh))'
+- regex: '^(?!com\.apple\.Safari\.SearchHelper|Safari|com\.apple\.WebKit\.Networking|NetworkingExtension).*(?:CFNetwork|Mana)/.+ Darwin/(\d+[.\d]+)(?!.*(?:x86_64|i386|PowerMac|Power%20Macintosh))'
   name: 'iOS'
   versions:
+    - regex: 'Darwin/25\.4\.0'
+      version: '26.4'
+    - regex: 'Darwin/25\.3\.0'
+      version: '26.3'
+    - regex: 'Darwin/25\.2\.0'
+      version: '26.2'
+    - regex: 'Darwin/25\.1\.0'
+      version: '26.1'
     - regex: 'Darwin/25\.0\.0'
-      version: '26'
+      version: '26.0'
+    - regex: 'Darwin/24\.6\.0'
+      version: '18.6'
     - regex: 'Darwin/24\.5\.0'
       version: '18.5'
     - regex: 'Darwin/24\.4\.0'
@@ -1634,11 +1786,21 @@
 ##########
 # Mac
 ##########
-- regex: '(?:CFNetwork|Mana|StudioDisplay)/.+Darwin(?:/|; )(?:[\d.]+).+(?:x86_64|i386|Power%20Macintosh)|(?:x86_64-apple-)?darwin(?:[\d.]+)|C?Python.*Darwin|PowerMac|com\.apple\.Safari\.SearchHelper|^(?:NetworkingExtension|Safari)'
+- regex: '(?:CFNetwork|Mana|StudioDisplay)/.+Darwin(?:/|; )(?:[\d.]+).+(?:x86_64|i386|Power%20Macintosh)|(?:x86_64-apple-)?darwin(?:[\d.]+)|C?Python.*Darwin|PowerMac|com\.apple\.Safari\.SearchHelper|^(?:com\.apple\.WebKit\.Networking|NetworkingExtension|Safari)'
   name: 'Mac'
   versions:
+    - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?25\.4\.0'
+      version: '26.4'
+    - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?25\.3\.0'
+      version: '26.3'
+    - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?25\.2\.0'
+      version: '26.2'
+    - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?25\.1\.0'
+      version: '26.1'
     - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?25\.0\.0'
-      version: '26'
+      version: '26.0'
+    - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?24\.6\.0'
+      version: '15.6'
     - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?24\.5\.0'
       version: '15.5'
     - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?24\.4\.0'
@@ -2002,6 +2164,10 @@
   name: 'HP-UX'
   version: '$1'
 
+- regex: 'BSD Four'
+  name: 'BSD'
+  version: '4'
+
 # ElectroBSD (https://www.fabiankeil.de/gehacktes/electrobsd/)
 - regex: 'ElectroBSD(?:[/ ]?(\d+[.\d]+))?'
   name: 'ElectroBSD'
@@ -2027,7 +2193,7 @@
   name: 'Syllable'
   version: '$1'
 
-- regex: 'IRIX(?:;64)?(?:[/ ]?(\d+[.\d]+))'
+- regex: 'IRIX(?:;?64)?(?:[/ ]?(\d+[.\d]+))?'
   name: 'IRIX'
   version: '$1'
 
@@ -2090,6 +2256,6 @@
 ##########
 # Java ME (Java Platform, Micro Edition)
 ##########
-- regex: 'Java ME|(J2ME|Profile)/MIDP|MIDP-(?:\d+[.\d]+)/CLDC|Configuration/CLDC|Java; U; MIDP|MMP/\d\.\d'
+- regex: 'Java ME|J2ME|Profile/MIDP|CLDC|Java; U; MIDP|MMP/\d\.\d'
   name: 'Java ME'
   version: ''

--- a/src/known_oss.rs
+++ b/src/known_oss.rs
@@ -206,6 +206,7 @@ fn available_operating_systems() -> HashMap<String, String> {
         ("RZD", "RazoDroiD"),
         ("SAB", "Sabayon"),
         ("SSE", "SUSE"),
+        ("OPS", "openSUSE"),
         ("SAF", "Sailfish OS"),
         ("SCI", "Scientific Linux"),
         ("SEE", "SeewoOS"),
@@ -254,6 +255,22 @@ fn available_operating_systems() -> HashMap<String, String> {
         ("VIZ", "ViziOS"),
         ("AZU", "Azure Linux"),
         ("RIS", "risingOS"),
+        ("NTX", "NuttX"),
+        ("CON", "Contiki"),
+        ("MNX", "MINIX"),
+        ("PLN", "Plan 9"),
+        ("LPU", "Linpus"),
+        ("ARC", "ArcaOS"),
+        ("GHO", "GhostBSD"),
+        ("ELM", "elementary OS"),
+        ("MOS", "Mocor OS"),
+        ("TIT", "Titan OS"),
+        ("KOL", "KolibriOS"),
+        ("COL", "Coolita OS"),
+        ("ORS", "Orsay"),
+        ("SMA", "Smartisan OS"),
+        ("OHS", "OpenHarmony"),
+        ("BS1", "BSD"),
     ]
     .into_iter()
     .map(|(short, name)| (short.to_owned(), name.to_owned()))
@@ -267,6 +284,7 @@ fn os_families() -> HashMap<String, Vec<String>> {
             vec![
                 "AND", "CYN", "FIR", "REM", "RZD", "MLD", "MCD", "YNS", "GRI", "HAR", "ADR", "CLR",
                 "BOS", "REV", "LEN", "SIR", "RRS", "WER", "PIC", "ARM", "HEL", "BYI", "RIS", "PUF", "MET", "LEA",
+                "OHS", "SMA",
             ],
         ),
         ("AmigaOS", vec!["AMG", "MOR", "ARO"]),
@@ -277,7 +295,7 @@ fn os_families() -> HashMap<String, Vec<String>> {
         ("Firefox OS", vec!["FOS", "KOS"]),
         ("Gaming Console", vec!["WII", "PS3"]),
         ("Google TV", vec!["GTV"]),
-        ("IBM", vec!["OS2"]),
+        ("IBM", vec!["OS2", "ARC"]),
         ("iOS", vec!["IOS", "ATV", "WAS", "IPA"]),
         ("RISC OS", vec!["ROS"]),
         (
@@ -290,28 +308,29 @@ fn os_families() -> HashMap<String, Vec<String>> {
                 "TEN", "CST", "NOV", "ROU", "ZOR", "RED", "KAL", "ORA", "VID", "TIV", "BSN", "RAS",
                 "UOS", "PIO", "FRI", "LIR", "WEB", "SER", "ASP", "AOS", "LOO", "EUL", "SCI", "ALP",
                 "CLO", "ROC", "OVZ", "PVE", "RST", "EZX", "GNS", "JOL", "TUR", "QTP", "WPO", "PAN", "VIZ", "AZU",
+                "COL", "ELM", "LPU", "OPS",
             ],
         ),
         ("Mac", vec!["MAC"]),
         ("Mobile Gaming Console", vec!["PSP", "NDS", "XBX"]),
         ("OpenVMS", vec!["OVS"]),
-        ("Real-time OS", vec!["MTK", "TDX", "MRE", "JME", "REX", "RNX"]),
+        ("Real-time OS", vec!["MTK", "TDX", "MRE", "JME", "REX", "RNX", "KOL", "MOS", "NTX"]),
         (
             "Other Mobile",
-            vec!["WOS", "POS", "SBA", "TIZ", "SMG", "MAE", "LUN", "GEO"],
+            vec!["WOS", "POS", "SBA", "TIZ", "SMG", "MAE", "LUN", "GEO", "CON"],
         ),
         ("Symbian", vec!["SYM", "SYS", "SY3", "S60", "S40"]),
         (
             "Unix",
             vec![
                 "SOS", "AIX", "HPX", "BSD", "NBS", "OBS", "DFB", "SYL", "IRI", "T64", "INF", "ELE",
-                "GNX", "ULT", "NWS", "NXT", "SBL",
+                "GNX", "ULT", "NWS", "NXT", "SBL", "GHO", "PLN", "MNX", "BS1",
             ],
         ),
         ("WebTV", vec!["WTV"]),
         ("Windows", vec!["WIN"]),
         ("Windows Mobile", vec!["WPH", "WMO", "WCE", "WRT", "WIO", "KIN"]),
-        ("Other Smart TV", vec!["WHS"]),
+        ("Other Smart TV", vec!["WHS", "TIT", "ORS"]),
     ]
     .into_iter()
     .map(|(brand, families)| {

--- a/src/parsers/oss.rs
+++ b/src/parsers/oss.rs
@@ -103,16 +103,22 @@ pub fn lookup(ua: &str, client_hints: Option<&ClientHint>) -> Result<Option<OS>>
 
                 if let Some(platform_version) = &client_hints.platform_version {
                     if os.name == "Windows" {
-                        if let Some(major_version) = platform_version
-                            .split('.')
-                            .next()
-                            .and_then(|x| x.parse::<u32>().ok())
-                        {
-                            if major_version > 0 && major_version < 11 {
-                                version = Some("10".to_owned());
-                            } else if major_version > 10 {
-                                version = Some("11".to_owned());
-                            }
+                        let parts: Vec<&str> = platform_version.split('.').collect();
+                        let major_version = parts.first().and_then(|x| x.parse::<u32>().ok()).unwrap_or(0);
+                        let minor_version = parts.get(1).and_then(|x| x.parse::<u32>().ok()).unwrap_or(0);
+
+                        if major_version == 0 {
+                            // 0.x.0 maps to older Windows versions
+                            version = match minor_version {
+                                1 => Some("7".to_owned()),
+                                2 => Some("8".to_owned()),
+                                3 => Some("8.1".to_owned()),
+                                _ => version, // keep as "0.0.0" etc. for later adjustment
+                            };
+                        } else if major_version > 0 && major_version < 11 {
+                            version = Some("10".to_owned());
+                        } else if major_version > 10 {
+                            version = Some("11".to_owned());
                         }
                     }
                 }
@@ -132,7 +138,11 @@ pub fn lookup(ua: &str, client_hints: Option<&ClientHint>) -> Result<Option<OS>>
         }
     });
 
-    let os_from_ua: Option<OS> = OS_LIST.lookup(ua)?;
+    // Restore UA from client hints model name for accurate detection (e.g., Chrome OS codenames)
+    let restored_ua = restore_ua_from_client_hints(ua, client_hints);
+    let effective_ua = restored_ua.as_deref().unwrap_or(ua);
+
+    let os_from_ua: Option<OS> = OS_LIST.lookup(effective_ua)?;
 
     // various occasional overrides of client hint information based on ua.
     if let Some(ref mut os_from_hints) = &mut os_from_hints {
@@ -150,7 +160,15 @@ pub fn lookup(ua: &str, client_hints: Option<&ClientHint>) -> Result<Option<OS>>
             // detailed
             if let Some(ua_family) = &os_from_ua.family {
                 if *ua_family == os_from_hints.name {
+                    let prev_name = os_from_hints.name.clone();
                     os_from_hints.name = os_from_ua.name.clone();
+                    // When the OS name changes (e.g., Android → LeafOS), use the UA version by
+                    // default. Specialized OSes with no version regex will have ua version = None,
+                    // clearing the Android platform_version that doesn't apply to them.
+                    // If the name did NOT change (e.g., Windows), keep the hints-derived version.
+                    if os_from_hints.name != prev_name {
+                        os_from_hints.version = os_from_ua.version.clone();
+                    }
 
                     if os_from_hints.name == "HarmonyOS" {
                         os_from_hints.version = None;
@@ -170,10 +188,10 @@ pub fn lookup(ua: &str, client_hints: Option<&ClientHint>) -> Result<Option<OS>>
 
                             if let Some(version) = FIRE_OS_VERSION.get(os_hint_version) {
                                 os_from_hints.version = Some((*version).to_owned());
-                            } else {
-                                os_from_hints.version =
-                                    FIRE_OS_VERSION.get(major_version).map(|x| (*x).to_owned());
+                            } else if let Some(version) = FIRE_OS_VERSION.get(major_version) {
+                                os_from_hints.version = Some((*version).to_owned());
                             }
+                            // else: keep existing version unchanged
                         }
                     }
                 }
@@ -187,13 +205,21 @@ pub fn lookup(ua: &str, client_hints: Option<&ClientHint>) -> Result<Option<OS>>
             {
                 os_from_hints.name = os_from_ua.name.clone();
             }
+
+            // Chrome OS detected from UA codename (via restored UA) but client hints report Android
+            if os_from_hints.name == "Android" && os_from_ua.name == "Chrome OS" {
+                os_from_hints.name = os_from_ua.name.clone();
+                os_from_hints.version = None;
+                os_from_hints.family = os_from_ua.family.clone();
+                os_from_hints.desktop = os_from_ua.desktop;
+            }
         }
     }
 
-    let mut res = os_from_hints.or(os_from_ua);
+    let mut res = os_from_hints.or(os_from_ua.clone());
 
     if let Some(os) = &mut res {
-        if let platform @ Some(_) = parse_platform(ua, client_hints)? {
+        if let platform @ Some(_) = parse_platform(effective_ua, client_hints)? {
             os.platform = platform
         }
     }
@@ -262,7 +288,63 @@ pub fn lookup(ua: &str, client_hints: Option<&ClientHint>) -> Result<Option<OS>>
         }
     }
 
+    // Fix Windows version "0.0.0" — use the UA-detected version (or clear if it was "10")
+    if let Some(os) = &mut res {
+        if os.name == "Windows" && os.version.as_deref() == Some("0.0.0") {
+            if let Some(ua_version) = os_from_ua.as_ref().and_then(|u| u.version.as_deref()) {
+                os.version = if ua_version == "10" {
+                    None
+                } else {
+                    Some(ua_version.to_owned())
+                };
+            } else {
+                os.version = None;
+            }
+        }
+    }
+
     Ok(res)
+}
+
+fn restore_ua_from_client_hints(ua: &str, client_hints: Option<&ClientHint>) -> Option<String> {
+    static ANDROID_K_DETECT: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)Android (?:1[0-6][.\d]*; K(?:\s+Build/|[;)])|1[0-6]\))\s*AppleWebKit")
+            .expect("android k detect regex")
+    });
+    static ANDROID_K_REPLACE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)Android (?:10[.\d]*; K|1[1-6])").expect("android k replace regex")
+    });
+    static DESKTOP_DETECT: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?:Windows (?:NT|IoT)|X11; Linux x86_64)").expect("desktop detect regex")
+    });
+    static DESKTOP_EXCLUDE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"CE-HTML| Mozilla/|Andr[o0]id|Tablet|Mobile|iPhone|Windows Phone|ricoh|OculusBrowser|PicoBrowser|Lenovo|compatible; MSIE|Trident/|Tesla/|XBOX|FBMD/|ARM; ?[^)]+")
+            .expect("desktop exclude regex")
+    });
+    static X11_REPLACE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"X11; Linux x86_64").expect("x11 replace regex"));
+
+    let hints = client_hints?;
+    let model = hints.model.as_ref().filter(|m| !m.is_empty())?;
+
+    if ANDROID_K_DETECT.is_match(ua).unwrap_or(false)
+        && !ua.to_lowercase().contains("telegram-android/")
+    {
+        let os_version = hints.platform_version.as_deref().unwrap_or("10");
+        let replacement = format!("Android {}; {}", os_version, model);
+        let result = ANDROID_K_REPLACE.replace_all(ua, replacement.as_str());
+        return Some(result.into_owned());
+    }
+
+    if DESKTOP_DETECT.is_match(ua).unwrap_or(false)
+        && !DESKTOP_EXCLUDE.is_match(ua).unwrap_or(false)
+    {
+        let replacement = format!("X11; Linux x86_64; {}", model);
+        let result = X11_REPLACE.replace_all(ua, replacement.as_str());
+        return Some(result.into_owned());
+    }
+
+    None
 }
 
 fn parse_platform(ua: &str, client_hints: Option<&ClientHint>) -> Result<Option<String>> {
@@ -315,9 +397,7 @@ fn parse_platform(ua: &str, client_hints: Option<&ClientHint>) -> Result<Option<
     static SH4_REG: Lazy<Regex> = static_user_agent_match!("sh4");
     static SPARC64_REG: Lazy<Regex> = static_user_agent_match!("sparc64");
     static X64_REG: Lazy<Regex> = Lazy::new(|| {
-        // Don't match device model names like "Elephone_P3000S-64bit"
-        // The negative lookbehind ensures we don't match if preceded by a letter or underscore
-        Regex::new(r"(?i)(?<![\w_-])(?:64-?bit|WOW64|(?:Intel)?x64|WINDOWS_64|win64|x86_?64)\b|.*amd64").expect("x64 regex")
+        Regex::new(r"(?i)(?<![\w_-])(?:64-?bit|WOW64|(?:Intel)?x64|WINDOWS_64|win64|IRIX;?64)\b|.*(?:amd64|x86_?64)").expect("x64 regex")
     });
     static X86_REG: Lazy<Regex> = static_user_agent_match!(".*32bit|.*win32|(?:i[0-9]|x)86|i86pc");
 

--- a/tests/data/fixtures/feature_phone.yml
+++ b/tests/data/fixtures/feature_phone.yml
@@ -104,8 +104,8 @@
 -
   user_agent: GIONEE50_12864_11B_HW (MRE\\2.5.00(3072) resolution\\240320 chipset\\MT6250 touch\\1 tpannel\\0 camera\\1 gsensor\\0 keyboard\ormal) 1307SY_0201_V1045 Release/2013.06.28 WAP Browser/MAUI (HTTP PGDL; HTTPS) Profile/Profile/MIDP-2.0 Configuration/CLDC-1.1 Q03C1-2.40 en-US
   os:
-    name: Java ME
-    version: ""
+    name: MRE
+    version: "2.5.00"
     platform: ""
   client:
     type: browser
@@ -121,7 +121,10 @@
   browser_family: Unknown
 -
   user_agent: GIONEE S80/Q03C MAUI-browser/MIDP2.0/CLDC1.1/Screen-240X320
-  os: [ ]
+  os:
+    name: Java ME
+    version: ""
+    platform: ""
   client:
     type: browser
     name: MAUI WAP Browser
@@ -132,7 +135,7 @@
     type: feature phone
     brand: Gionee
     model: S80
-  os_family: Unknown
+  os_family: Real-time OS
   browser_family: Unknown
 -
   user_agent: Karbonn K222s WAP-Browser/1.0.0

--- a/tests/data/fixtures/parser/oss.yml
+++ b/tests/data/fixtures/parser/oss.yml
@@ -1,0 +1,5819 @@
+-
+  user_agent: Mozilla/6.0 (Macintosh; U; Amiga-AWeb) Safari 3.1
+  os:
+    name: AmigaOS
+    version: ""
+    platform: ""
+    family: AmigaOS
+-
+  user_agent: Mozilla/5.0 (AmigaOS; U; AmigaOS 1.3; en-US; rv:1.8.1.21) Gecko/20090303 SeaMonkey/1.1.15
+  os:
+    name: AmigaOS
+    version: "1.3"
+    platform: ""
+    family: AmigaOS
+-
+  user_agent: Mozilla/5.0 ArchLinux (X11; U; Linux x86_64; en-US) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30
+  os:
+    name: Arch Linux
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/3.0 (compatible; NetPositive/2.2.1; BeOS)
+  os:
+    name: BeOS
+    version: ""
+    platform: ""
+    family: BeOS
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686 (x86_64); en-US; rv:1.9.0.6) Gecko/2009020414 CentOS/3.0.6-1.el5.centos Firefox/3.0.6
+  os:
+    name: CentOS
+    version: "5"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; fr-fr) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/531.2+ Debian/squeeze (2.30.6-1) Epiphany/2.30.6
+  os:
+    name: Debian
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; de; rv:1.9.0.15) Gecko/2009102815 Iceweasel/3.0.6 (Debian-3.0.6-3)
+  os:
+    name: Debian
+    version: 3.0.6
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.8) Gecko Fedora/1.9.0.8-1.fc10 Kazehakase/0.5.6
+  os:
+    name: Fedora
+    version: "10"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Fire OS/5.3.6.2 stagefright/1.2 (Linux;Android 5.1.1)
+  os:
+    name: Fire OS
+    version: 5.3.6.2
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; FreeBSD amd64; rv:25.0) Gecko/20100101 Firefox/25.0
+  os:
+    name: FreeBSD
+    version: ""
+    platform: x64
+    family: Unix
+-
+  user_agent: Mozilla/3.0 (WorldGate Gazelle 3.5.1 build 11; FreeBSD2.2.8-STABLE)
+  os:
+    name: FreeBSD
+    version: 2.2.8
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (X11; U; Gentoo x86_64; de-DE) Firefox/26.0
+  os:
+    name: Gentoo
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 conkeror/1.0pre
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: MOT-A1600/1.0 LinuxOS/2.4.20 Release/8.22.2006 Browser/Opera8.00 Profile/MIDP-2.0 Configuration/CLDC-1.1 Software/R542_G_11.61.33R
+  os:
+    name: Motorola EZX
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (BeOS; U; Haiku BePC; en-US; rv:1.8.1.21pre) Gecko/20090218 BonEcho/2.0.0.21pre
+  os:
+    name: Haiku OS
+    version: ""
+    platform: ""
+    family: BeOS
+-
+  user_agent: Mozilla/5.0 (Macintosh; Intel Haiku R1 x86) AppleWebKit/605.1.17 (KHTML, like Gecko) WebPositive/1.2 Version/11.1 Safari/605.1.17
+  os:
+    name: Haiku OS
+    version: ""
+    platform: x86
+    family: BeOS
+-
+  user_agent: Mozilla/4.08 (Charon; Inferno)
+  os:
+    name: Inferno
+    version: ""
+    platform: ""
+    family: Unix
+-
+  user_agent: 'Mozilla/4.04 [en] (X11; I; IRIX 5.3 IP22)'
+  os:
+    name: IRIX
+    version: "5.3"
+    platform: ""
+    family: Unix
+-
+  user_agent: 'Mozilla/4.77 [en] (X11; I; IRIX;64 6.5 IP30)'
+  os:
+    name: IRIX
+    version: "6.5"
+    platform: x64
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (compatible; Konqueror/3.5; Linux) KHTML/3.5.5 (like Gecko) (Kubuntu)
+  os:
+    name: Kubuntu
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Mobile; LYF/F30C/LYF_F30C-000-09-10-140318; Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.0
+  os:
+    name: KaiOS
+    version: "2.0"
+    platform: ""
+    family: Firefox OS
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.0.1) Gecko/2008072820 Kubuntu/8.04 (hardy) Firefox/3.0.1
+  os:
+    name: Kubuntu
+    version: "8.04"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US) AppleWebKit/532.1 (KHTML, like Gecko) Arora/0.10.1 (Git: 1329 e5385f3) Safari/532.1'
+  os:
+    name: Mac
+    version: ""
+    platform: ""
+    family: Mac
+-
+  user_agent: QuickTime\xaa.7.0.4 (qtver=7.0.4;cpu=PPC;os=Mac 10.3.9)
+  os:
+    name: Mac
+    version: 10.3.9
+    platform: ""
+    family: Mac
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.17) Gecko/20110429 Mandriva Linux/1.9.2.17-0.1mdv2010.0 (2010.0) Firefox/3.6.17
+  os:
+    name: Mandriva
+    version: "2010.0"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; HTC Desire Build/GRI40; MildWild CM-8.0 JG Stable) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+  os:
+    name: MildWild
+    version: "8.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Macintosh; PowerPC MorphOS 3.7; Odyssey Web Browser; rv:1.23) AppleWebKit/538.1 (KHTML, like Gecko) OWB/1.23 Safari/538.1
+  os:
+    name: MorphOS
+    version: "3.7"
+    platform: ""
+    family: AmigaOS
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; Nexus One Build/GRK39F; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+  os:
+    name: CyanogenMod
+    version: 7.2.0
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6(RazoDroiD); fr-fr; GT-S5830i Build/RazoDroiD v2.0 by (rajrocks)rishee) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+  os:
+    name: RazoDroiD
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla 5.0 (Linux; U; Android 2.3.5; zh-cn; ZTE U793 Build MocorDroid2.3.5) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+  os:
+    name: MocorDroid
+    version: 2.3.5
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux armv7l; pt-PT; rv:1.9.2.3pre) Gecko/20100723 Firefox/3.5 Maemo Browser 1.7.4.8 RX-51 N900
+  os:
+    name: Maemo
+    version: ""
+    platform: ARM
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; es-ES; rv:2.0) Gecko/20100101 Linux Mint 16/Petra Firefox/25.0.1.
+  os:
+    name: Mint
+    version: "16"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; NetBSD amd64; fr-FR; rv:1.8.0.7) Gecko/20061102 Firefox/1.5.0.7
+  os:
+    name: NetBSD
+    version: ""
+    platform: x64
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (X11; OpenBSD amd64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.45 Safari/537.36
+  os:
+    name: OpenBSD
+    version: ""
+    platform: x64
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (OS/2; Warp 4.5; rv:10.0.12) Gecko/20100101 Firefox/10.0.12
+  os:
+    name: OS/2
+    version: "4.5"
+    platform: ""
+    family: IBM
+-
+  user_agent: Mozilla/3.0 (X11; I; OSF1 V4.0 alpha)
+  os:
+    name: OSF1
+    version: "4.0"
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (compatible; Konqueror/4.3; Linux) KHTML/4.3.4 (like Gecko) Red Hat Enterprise Linux/4.3.4-19.el6
+  os:
+    name: Red Hat
+    version: 4.3.4
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Opera/9.80 (X11; Linux x86_64; Sabayon) Presto/2.12.388 Version/12.16
+  os:
+    name: Sabayon
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Slackware/Chrome/12.0.742.100 Safari/534.30
+  os:
+    name: Slackware
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.2) Gecko/20090729 Slackware/13.0 Firefox/3.5.2
+  os:
+    name: Slackware
+    version: "13.0"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; SunOS i86pc; en-US; rv:1.9.1.9) Gecko/20100525 Firefox/3.5.9
+  os:
+    name: Solaris
+    version: ""
+    platform: x86
+    family: Unix
+-
+  user_agent: Mozilla/4.0 (compatible; MSIE 5.0; SunOS 5.10 sun4u; X11)
+  os:
+    name: Solaris
+    version: "5.10"
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.24) Gecko/20111101 SUSE/3.6.24-0.2.1 Firefox/3.6.24
+  os:
+    name: SUSE
+    version: 3.6.24
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (compatible; U; ABrowse 0.6; Syllable) AppleWebKit/420+ (KHTML, like Gecko)
+  os:
+    name: Syllable
+    version: ""
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/31.0.1650.63 Chrome/31.0.1650.63 Safari/537.36
+  os:
+    name: Ubuntu
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1.13) Gecko/20080313 SeaMonkey/1.1.9 (Ubuntu-1.1.9+nobinonly-0ubuntu1)
+  os:
+    name: Ubuntu
+    version: 1.1.9
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; it-IT; rv:1.9.0.2) Gecko/2008092313 Ubuntu/9.25 (jaunty) Firefox/3.8
+  os:
+    name: Ubuntu
+    version: "9.25"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Windows; U; Win9x; en; Stable) Gecko/20020911 Beonex/0.8.1-stable
+  os:
+    name: Windows
+    version: ""
+    platform: ""
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Windows NT 6.4; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko
+  os:
+    name: Windows
+    version: "10"
+    platform: x64
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko
+  os:
+    name: Windows
+    version: "10"
+    platform: x64
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Windows IoT 10.0; Android 6.0.1; WebView/3.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Mobile Safari/537.36 Edge/17.17083
+  os:
+    name: Windows IoT
+    version: "10"
+    platform: ""
+    family: Windows Mobile
+-
+  user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; de; rv:1.8.1.20) Gecko/20081217 Firefox/2.0.0.20
+  os:
+    name: Windows
+    version: "2000"
+    platform: ""
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.4.9999.1900 Safari/537.31 BDSpark/26.4
+  os:
+    name: Windows
+    version: "7"
+    platform: x64
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.57 Safari/537.17
+  os:
+    name: Windows
+    version: "8"
+    platform: x64
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64; rv:26.0) Gecko/20100101 Firefox/26.0
+  os:
+    name: Windows
+    version: "8.1"
+    platform: x64
+    family: Windows
+-
+  user_agent: Mozilla/2.0 (compatible; MSIE 3.02; Update a; AOL 3.0; Windows 95)
+  os:
+    name: Windows
+    version: "95"
+    platform: ""
+    family: Windows
+-
+  user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; Win 9x 4.90; .NET CLR 1.1.4322)
+  os:
+    name: Windows
+    version: ME
+    platform: ""
+    family: Windows
+-
+  user_agent: Mozilla/4.0 (compatible; MSIE 4.01; Digital AlphaServer 1000A 4/233; Windows NT; Powered By 64-Bit Alpha Processor)
+  os:
+    name: Windows
+    version: NT
+    platform: x64
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.2 x64; en-US; rv:1.9a1) Gecko/20061007 Minefield/3.0a1
+  os:
+    name: Windows
+    version: Server 2003
+    platform: x64
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Windows NT 6.0; WOW64; rv:18.0) Gecko/20100101 Firefox/18.0
+  os:
+    name: Windows
+    version: Vista
+    platform: x64
+    family: Windows
+-
+  user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; Avant Browser; InfoPath.1)
+  os:
+    name: Windows
+    version: XP
+    platform: ""
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 0.5; en-us) AppleWebKit/522+ (KHTML, like Gecko) Safari/419.3
+  os:
+    name: Android
+    version: "0.5"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Acer; Allegro)
+  os:
+    name: Windows Phone
+    version: "7.5"
+    platform: ""
+    family: Windows Mobile
+-
+  user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 928) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
+  os:
+    name: Windows Phone
+    version: "8.1"
+    platform: ARM
+    family: Windows Mobile
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; E310 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 ACER_E310/1.300.05
+  os:
+    name: Android
+    version: 2.2.2
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; Pixel XL Build/PPR1.180610.009) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) acer_F900
+  os:
+    name: Windows CE
+    version: ""
+    platform: ""
+    family: Windows Mobile
+-
+  user_agent: Mozilla/5.0 (Mobile; ALCATEL ONE TOUCH 4012A; rv:18.1) Gecko/18.1 Firefox/18.1
+  os:
+    name: Firefox OS
+    version: ""
+    platform: ""
+    family: Firefox OS
+-
+  user_agent: AtomicBrowser/3.7.1 CFNetwork/467.12 Darwin/10.3.1
+  os:
+    name: iOS
+    version: "3.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; ru-ru) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8B117
+  os:
+    name: iOS
+    version: "4.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: CFNetwork/758.2.8 Darwin/15.0.0
+  os:
+    name: iOS
+    version: "9.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: CFNetwork/758.3.15 Darwin/15.4.0
+  os:
+    name: iOS
+    version: "9.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: SPORT1/4059 CFNetwork/758.4.3 Darwin/15.5.0
+  os:
+    name: iOS
+    version: 9.3.2
+    platform: ""
+    family: iOS
+-
+  user_agent: Interflora/22 CFNetwork/808.0.1 Darwin/16.0.0
+  os:
+    name: iOS
+    version: "10.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/602.1 CFNetwork/808.1.3 Darwin/16.1.0
+  os:
+    name: iOS
+    version: "10.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/602.1 CFNetwork/808.2.16 Darwin/16.3.0
+  os:
+    name: iOS
+    version: "10.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/602.1 CFNetwork/811.5.4 Darwin/16.6.0
+  os:
+    name: iOS
+    version: "10.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/602.1 CFNetwork/808.3 Darwin/16.3.0
+  os:
+    name: iOS
+    version: "10.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/887 Darwin/17.0.0
+  os:
+    name: iOS
+    version: "11.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/889.9 Darwin/17.2.0
+  os:
+    name: iOS
+    version: "11.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: NokiaN73-2/3.0-630.0.2 Series60/3.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+  os:
+    name: Symbian OS Series 60
+    version: "3.0"
+    platform: ""
+    family: Symbian
+-
+  user_agent: XBMC/PRE-11.0 Git:20110623-62171b3 (iOS; 11.0.0 AppleTV2,1; http://www.xbmc.org)
+  os:
+    name: tvOS
+    version: 11.0.0
+    platform: ARM
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7230E-VODAFONE/S723EBUJJ3; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
+  os:
+    name: Bada
+    version: "1.0"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: BlackBerry8520/5.0.0.681 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/134
+  os:
+    name: BlackBerry OS
+    version: 5.0.0.681
+    platform: ""
+    family: BlackBerry
+-
+  user_agent: Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML, like Gecko) Version/7.2.1.0 Safari/536.2+
+  os:
+    name: BlackBerry Tablet OS
+    version: 2.1.0
+    platform: ""
+    family: BlackBerry
+-
+  user_agent: NetFront/4.2 (BMP 1.0.4; U; en-us; LG; NetFront/4.2/AMB) Boost LG272 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+  os:
+    name: Brew
+    version: 1.0.4
+    platform: ""
+    family: Brew
+-
+  user_agent: Mozilla/5.0 (X11; CrOS x86_64 4731.101.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.67 Safari/537.36
+  os:
+    name: Chrome OS
+    version: 4731.101.0
+    platform: x64
+    family: Chrome OS
+-
+  user_agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Large Screen Safari/534.24 GoogleTV/092754
+  os:
+    name: Google TV
+    version: "092754"
+    platform: x86
+    family: Google TV
+-
+  user_agent: Opera/9.80 (MTK; Nucleus; U; en-US) Presto/2.4.18 Version/10.00
+  os:
+    name: MTK / Nucleus
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: UNTRUSTED/1.0/HS-T39_TD/1.0 Release/03.03.2011 Threadx/4.0 Mocor/W10 Browser/NF4.0 Profile/MIDP-2.0 Config/CLDC-1.1
+  os:
+    name: ThreadX
+    version: "4.0"
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13
+  os:
+    name: MeeGo
+    version: ""
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (PLAYSTATION 3 4.46) AppleWebKit/531.22.8 (KHTML, like Gecko)
+  os:
+    name: PlayStation
+    version: 3.4.46
+    platform: ""
+    family: Gaming Console
+-
+  user_agent: Mozilla/5.0 (PlayStation; PlayStation 5/2.26) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15
+  os:
+    name: PlayStation
+    version: 5.2.26
+    platform: ""
+    family: Gaming Console
+-
+  user_agent: 'Mozilla/5.0 [ja] (Playstation2; Linux 2.4.20 MIPS; ja-JP; rv:1.8a2) Gecko/20040630'
+  os:
+    name: PlayStation
+    version: 2.4.20
+    platform: MIPS
+    family: Gaming Console
+-
+  user_agent: Mozilla/5.0 (PlayStation 4 Pro 5.0)
+  os:
+    name: PlayStation
+    version: 4.5.0
+    platform: ""
+    family: Gaming Console
+-
+  user_agent: Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US
+  os:
+    name: Nintendo
+    version: Wii
+    platform: ""
+    family: Gaming Console
+-
+  user_agent: Bunjalloo/0.7.6(Nintendo DS;U;en)
+  os:
+    name: Nintendo Mobile
+    version: DS
+    platform: ""
+    family: Mobile Gaming Console
+-
+  user_agent: Mozilla/5.0 (Nintendo 3DS; U; ; en) Version/1.7498.EU
+  os:
+    name: Nintendo Mobile
+    version: 3DS
+    platform: ""
+    family: Mobile Gaming Console
+-
+  user_agent: Mozilla/4.0 (PlayStation Portable); 2.00)
+  os:
+    name: PlayStation Portable
+    version: Portable
+    platform: ""
+    family: Mobile Gaming Console
+-
+  user_agent: Mozilla/5.0 (PlayStation Vita 3.01) AppleWebKit/536.26 (KHTML, like Gecko) Silk/3.2
+  os:
+    name: PlayStation Portable
+    version: Vita
+    platform: ""
+    family: Mobile Gaming Console
+-
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chrome/38.0.2125.122 Safari/537.36 WebAppManager
+  os:
+    name: webOS
+    version: "3"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (webOS/1.4.5; U; ru-RU) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pixi/1.0
+  os:
+    name: webOS
+    version: 1.4.5
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chr0me/38.0.2125.122 Safari/537.36 LG Browser/8.00.00(LGE; WEBOS3; 03.00.65; 1; DTV_W16R); webOS.TV-2016; LG NetCast.TV-2013 Compatible (LGE, WEBOS3, wired)
+  os:
+    name: webOS
+    version: "3"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/538.2 (KHTML, like Gecko) Large Screen Safari/538.2 LG Browser/7.00.00(LGE; WEBOS1; 00.00.00; 1); webOS.TV-2014; LG NetCast.TV-2013 Compatible (LGE, WEBOS1, wired)
+  os:
+    name: webOS
+    version: "1"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36 WebAppManager
+  os:
+    name: webOS
+    version: "6"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: CorePlayer/1.0 (Palm OS 5.4.9; ARM Intel PXA27x; en) CorePlayer/1.3.2_6909
+  os:
+    name: palmOS
+    version: 5.4.9
+    platform: ARM
+    family: Other Mobile
+-
+  user_agent: 'Palmscape/3.0J [ja] (v. 3.5.2H1.5; 153x130; c8)'
+  os:
+    name: palmOS
+    version: ""
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Browse/0.6 (Linux 3.10.0+; RemixOS 5.1.1; RemixOS SDK built for x86; en_us) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.0.0 Desktop (Opera Mini/Compression)
+  os:
+    name: Remix OS
+    version: "1"
+    platform: x86
+    family: Android
+-
+  user_agent: Browse/0.6.mini (Linux 3.4.0+; RemixOS 6.0; Motorola Moto G 2014; en_us) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.119 Desktop
+  os:
+    name: Remix OS
+    version: "2"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 2.3 YunOs 1.0.0.3; zh-cn; K-Touch W658 Build/AliyunOs-2012) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+  os:
+    name: YunOS
+    version: 1.0.0.3
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch; ARMBJS)
+  os:
+    name: Windows RT
+    version: ""
+    platform: ARM
+    family: Windows Mobile
+-
+  user_agent: Mozilla/5.0 (Windows NT 6.3; ARM; Trident/7.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0; rv:11.0) like Gecko
+  os:
+    name: Windows RT
+    version: "8.1"
+    platform: ARM
+    family: Windows Mobile
+-
+  user_agent: Opera/9.80 (Windows Mobile; WCE; Opera Mobi/WMD-50433; U; en) Presto/2.4.13 Version/10.00
+  os:
+    name: Windows Mobile
+    version: ""
+    platform: ""
+    family: Windows Mobile
+-
+  user_agent: Opera/9.7 (WindowsMobile; PPC; Opera Mobi/35267; U; en; Presto/2.1.1)
+  os:
+    name: Windows Mobile
+    version: ""
+    platform: ""
+    family: Windows Mobile
+-
+  user_agent: Mozilla/3.0 WebTV/1.2 (compatible; MSIE 2.0)
+  os:
+    name: WebTV
+    version: "1.2"
+    platform: ""
+    family: WebTV
+-
+  user_agent: Mozilla/5.0 (Linux; U; Tizen/1.0 like Android; en-us; AppleWebKit/534.46 (KHTML, like Gecko) Tizen Browser/1.0 Mobile
+  os:
+    name: Tizen
+    version: "1.0"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (Symbian/3; Series60/5.2 Nokia500/010.029; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/533.4 (KHTML, like Gecko) NokiaBrowser/7.3.1.37 Mobile Safari/533.4 3gpp-gba
+  os:
+    name: Symbian^3
+    version: Anna
+    platform: ""
+    family: Symbian
+-
+  user_agent: Mozilla/5.0 (Series40; Nokia306/03.63; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/3.9.0.0.22
+  os:
+    name: Symbian OS Series 40
+    version: ""
+    platform: ""
+    family: Symbian
+-
+  user_agent: Nokia210/2.0 (04.12) Profile/MIDP-2.1 Configuration/CLDC-1.1 UCWEB/2.0 (Java; U; MIDP-2.0; en-US; Nokia210) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile
+  os:
+    name: Symbian
+    version: ""
+    platform: ""
+    family: Symbian
+-
+  user_agent: Mozilla/5.0 (Symbian; U; N8-00; xx) AppleWebKit/534.3 (KHTML, like Gecko) MiniBrowserMobile/4.0 Mobile Safari/534.3
+  os:
+    name: Symbian OS
+    version: ""
+    platform: ""
+    family: Symbian
+-
+  user_agent: Mozilla/5.0 (Maemo; Linux; U; Jolla; Sailfish; Mobile; rv:26.0) Gecko/26.0 Firefox/26.0 SailfishBrowser/1.0 like Safari/538.1
+  os:
+    name: Sailfish OS
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: 'Mozilla/1.10 [en] (Compatible; RISC OS 3.70; Oregano 1.10)'
+  os:
+    name: RISC OS
+    version: "3.70"
+    platform: ""
+    family: RISC OS
+-
+  user_agent: Mozilla/5.0 (X11; U; AIX 5.3; en-US; rv:1.7.12) Gecko/20051025
+  os:
+    name: AIX
+    version: "5.3"
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (compatible; Konqueror/4.1; DragonFly) KHTML/4.1.4 (like Gecko)
+  os:
+    name: DragonFly
+    version: ""
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (X11; U; HP-UX 9000/785; es-ES; rv:1.0.1) Gecko/20020827 Netscape/7.0
+  os:
+    name: HP-UX
+    version: "9000"
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (X11; Knoppix; Linux i686; rv:20.0) Gecko/20100101 Firefox/20.0
+  os:
+    name: Knoppix
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-GB; rv:1.9.1.3) Gecko/20090824 Firefox/3.5.3 (VectorLinux package 3.5.3-1vl60)
+  os:
+    name: VectorLinux
+    version: 3.5.3
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: 'Mozilla/5.0 (SymbianOS/9.1; U; [en-us]) AppleWebKit/413 (KHTML, like Gecko) Safari/413'
+  os:
+    name: Symbian OS
+    version: "9.1"
+    platform: ""
+    family: Symbian
+-
+  user_agent: Mozilla/1.22 (compatible; MSIE 2.0; Windows 3.1)
+  os:
+    name: Windows
+    version: "3.1"
+    platform: ""
+    family: Windows
+-
+  user_agent: Mozilla/4.0 (compatible; MSIE 4.01; Windows 98)
+  os:
+    name: Windows
+    version: "98"
+    platform: ""
+    family: Windows
+-
+  user_agent: XBMC/3.3-DEV-r31572 (Xbox; http://www.xbmc.org)
+  os:
+    name: Xbox
+    version: "360"
+    platform: ""
+    family: Mobile Gaming Console
+-
+  user_agent: Mozilla/5.0 (X11; Linux i686; rv:7.0.1) Firefox/17.0 Xubuntu 12.10
+  os:
+    name: Xubuntu
+    version: "12.10"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Opera/9.80 (X11; Linux i686; U; lubuntu 10.10; en) Presto/2.7
+  os:
+    name: Lubuntu
+    version: "10.10"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/4.0 (X11; BackTrack; Linux i686; rv:10.0.2) Gecko/20100101 Firefox/4.0
+  os:
+    name: BackTrack
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Instacast/4.5.4 CFNetwork/672.1.14 Darwin/14.0.0
+  os:
+    name: iOS
+    version: "7.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: InstacastHD/1.1.2 CFNetwork/711.0.6 Darwin/14.0.0
+  os:
+    name: iOS
+    version: "8.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: 'Instacast/2380 CFNetwork/673.3 Darwin/13.4.0 (x86_64) (MacBookPro5%2C4)'
+  os:
+    name: Mac
+    version: 10.9.5
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/12602.3.12.0.1 CFNetwork/807.2.14 Darwin/16.3.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.12.2
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/12603.3.8 CFNetwork/811.5.4 Darwin/16.7.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.12.6
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/13604.1.38.1.6 CFNetwork/887 Darwin/17.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.13"
+    platform: x64
+    family: Mac
+-
+  user_agent: Podcasts/2.1.2
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: Shifty Jelly Pocket Casts, Android v4.4.3.1
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Shifty Jelly Pocket Casts, iOS v4.3
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Linux; U; en-us; BeyondPod)
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Overcast/1.0 (+http://overcast.fm/; iOS podcast app)
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: Podkicker Pro/1.9.4
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Castro/64 CFNetwork/672.1.15 Darwin/14.0.0
+  os:
+    name: iOS
+    version: "7.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Linux; U; Windows NT 6.1; en-us; dream) DoggCatcher
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: iTunes-iPod/6.1.6 (4; 16GB; dt:71)
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: TwitterAndroid/7.73.0-release.17 (8900198-r-17) HUAWEI VNS-L53/7.0 (HUAWEI;HUAWEI VNS-L53;HUAWEI;VNS-L53;0;;1;2013)
+  os:
+    name: Android
+    version: "7.0"
+    platform: ""
+    family: Android
+-
+  user_agent: TwitterAndroid/7.71.1-release.15 (8900196-r-15) TA-1028/8.0.0 (HMD Global;TA-1028;Nokia;TA-1028_00WW;0;;1;2013)
+  os:
+    name: Android
+    version: 8.0.0
+    platform: ""
+    family: Android
+-
+  user_agent: RSSRadio/9220 (iPad;iOS;12.3.1)
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: RSSRadio/9252
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: RSSRadio/
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; Linux i686; rv:45.0) Gecko/20100101 Firefox/45.0 Ordissimo/3.8.6.6+svn37147
+  os:
+    name: Ordissimo
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux i686 on x86_64; rv:52.0) Gecko/20100101 Firefox/52.0 Ordissimo/3.8.20+svn37598
+  os:
+    name: Ordissimo
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux i686; rv:45.0) Gecko/20100101 Firefox/45.0 webissimo3/3.7.30+svn32090
+  os:
+    name: Ordissimo
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux i686 on x86_64; rv:42.0) Gecko/20100101 Firefox/42.0 webissimo3/3.7.22+svn30377
+  os:
+    name: Ordissimo
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11 TOS; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 ToGate/72.0.3626.109 Safari/537.36
+  os:
+    name: TmaxOS
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: SAGETEL61D_11C_HW MRE/3.1.00900;MAUI/ARTEL_M5_V07_20171117_MP;BDATE/2017/11/17 15:42;LCD/128160;CHIP/MT6261;KEY/Normal;TOUCH/0;CAMERA/1;SENSOR/0;DEV/SAGETEL61D_11C_HW;WAP Browser/MAUI ;GMOBI/001;MBOUNCE/002;MOMAGIC/003;INDEX/004;SPICEI2I/005;GAMELOFT/006;
+  os:
+    name: MRE
+    version: "3.1"
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: Mozilla/5.0 (X11; OS ROSA; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36
+  os:
+    name: Rosa
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; CrOS x86_64 11151.23.2020; SeewoOS x86_64 2.0.16.3558) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.139 Safari/537.36 SeewoBrowser/2.0.16.3558
+  os:
+    name: SeewoOS
+    version: 2.0.16.3558
+    platform: x64
+    family: Chrome OS
+-
+  user_agent: Mozilla/5.0 (Freebox; Linux i686) AppleWebKit/538.1 (KHTML, like Gecko) Navigateur web/1.0 Safari/538.1
+  os:
+    name: Freebox
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64; Deepin 15.11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.75 Safari/537.36 NFSBrowser/5.0.5.2050
+  os:
+    name: Deepin
+    version: "15.11"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Safari/11603.1.30.0.34 CFNetwork/760.6.3 Darwin/15.6.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.11.6
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/13605.1.33.1.4 CFNetwork/897.15 Darwin/17.5.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.13.4
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/13606.3.4.1.4 CFNetwork/902.1 Darwin/17.7.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.13.6
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/13604.5.6 CFNetwork/893.13.1 Darwin/17.4.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.13.3
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/13604.3.5 CFNetwork/889.9 Darwin/17.2.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.13.1
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/13604.1.38.1.6 CFNetwork/887 Darwin/17.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.13"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/13605.2.8 CFNetwork/901.1 Darwin/17.6.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.13.5
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/14607.3.9 CFNetwork/978.0.7 Darwin/18.7.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.14"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/14606.4.5 CFNetwork/976 Darwin/18.2.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.14.1
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/14606.2.104.1.1 CFNetwork/975.0.3 Darwin/18.2.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.14.1
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/14606.1.36.1.9 CFNetwork/974.1 Darwin/18.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.14"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/14606.1.32 CFNetwork/971 Darwin/18.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.14"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/14606.1.24.40.1 CFNetwork/962 Darwin/18.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.14"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/14606.1.30 CFNetwork/969 Darwin/18.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.14"
+    platform: x64
+    family: Mac
+-
+  user_agent: Podcasts/1400.190 CFNetwork/1088.1 Darwin/19.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.15"
+    platform: x64
+    family: Mac
+-
+  user_agent: Podcasts/1400.203 CFNetwork/1091 Darwin/19.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.15"
+    platform: x64
+    family: Mac
+-
+  user_agent: Podcasts/1400.219.5 CFNetwork/1098 Darwin/19.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.15"
+    platform: x64
+    family: Mac
+-
+  user_agent: Podcasts/1410.10 CFNetwork/1103 Darwin/19.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.15"
+    platform: x64
+    family: Mac
+-
+  user_agent: Podcasts/1410.10 CFNetwork/1085.4 Darwin/19.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.15"
+    platform: x64
+    family: Mac
+-
+  user_agent: Podcasts/1410.10 CFNetwork/1082.3.1 Darwin/19.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.15"
+    platform: x64
+    family: Mac
+-
+  user_agent: MobileSafari/604.1 CFNetwork/978.0.7 Darwin/18.5.0
+  os:
+    name: iOS
+    version: "12.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/976 Darwin/18.2.0
+  os:
+    name: iOS
+    version: "12.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/975.0.3 Darwin/18.2.0
+  os:
+    name: iOS
+    version: "12.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/974.2.1 Darwin/18.0.0
+  os:
+    name: iOS
+    version: "12.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/602.1 CFNetwork/811.5.4 Darwin/16.7.0
+  os:
+    name: iOS
+    version: "10.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/902.2 Darwin/17.7.0
+  os:
+    name: iOS
+    version: 11.4.1
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/901.1 Darwin/17.6.0
+  os:
+    name: iOS
+    version: "11.4"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/978.0.7 Darwin/18.6.0
+  os:
+    name: iOS
+    version: "12.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/978.0.7 Darwin/18.7.0
+  os:
+    name: iOS
+    version: "12.4"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1125 Darwin/19.0.0
+  os:
+    name: iOS
+    version: "13.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1121.2.2 Darwin/19.2.0
+  os:
+    name: iOS
+    version: "13.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1121.2.2 Darwin/19.3.0
+  os:
+    name: iOS
+    version: 13.3.1
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1125.2 Darwin/19.4.0
+  os:
+    name: iOS
+    version: "13.4"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1126 Darwin/19.5.0
+  os:
+    name: iOS
+    version: "13.5"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1128.0.1 Darwin/19.6.0
+  os:
+    name: iOS
+    version: "13.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1197 Darwin/20.0.0
+  os:
+    name: iOS
+    version: "14.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1206 Darwin/20.1.0
+  os:
+    name: iOS
+    version: "14.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1209 Darwin/20.2.0
+  os:
+    name: iOS
+    version: "14.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: CFNetwork/1121.1.2 Darwin/19.2.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.15.2
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/15608.5.11 CFNetwork/1121.1.2 Darwin/19.3.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.15.3
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/15609.1.20.111.8 CFNetwork/1125.2 Darwin/19.4.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.15.4
+    platform: x64
+    family: Mac
+-
+  user_agent: com.apple.Safari.SearchHelper/15609.2.9.1.2 CFNetwork/1126 Darwin/19.5.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.15.5
+    platform: x64
+    family: Mac
+-
+  user_agent: com.apple.Safari.SearchHelper/15609.3.5.1.3 CFNetwork/1128.0.1 Darwin/19.6.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.15.6
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/16610.1.21.1.2 CFNetwork/1195 Darwin/20.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "11.0"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/16610.1.21.1.2 CFNetwork/1195 Darwin/20.1.0 (x86_64)
+  os:
+    name: Mac
+    version: "11.0"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/16610.1.21.1.2 CFNetwork/1195 Darwin/20.2.0 (x86_64)
+  os:
+    name: Mac
+    version: "11.1"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/13604.4.6 CFNetwork/893.10 Darwin/17.3.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.13.2
+    platform: x64
+    family: Mac
+-
+  user_agent: Mail/3273 CFNetwork/811.5.4 Darwin/16.6.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.12.5
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/12602.2.14.0.7 CFNetwork/807.1.3 Darwin/16.1.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.12.1
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/12602.2.14.0.7 CFNetwork/807.1.3 Darwin/16.2.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.12.2
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/12603.1.30.0.34 CFNetwork/811.4.18 Darwin/16.5.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.12.4
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/11601.3.9 CFNetwork/760.2.6 Darwin/15.2.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.11.2
+    platform: x64
+    family: Mac
+-
+  user_agent: com.apple.Safari.SearchHelper/11601.4.2 CFNetwork/760.2.6 Darwin/15.3.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.11.3
+    platform: x64
+    family: Mac
+-
+  user_agent: com.apple.Safari.SearchHelper/11601.5.17 CFNetwork/760.4.2 Darwin/15.4.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.11.4
+    platform: x64
+    family: Mac
+-
+  user_agent: com.apple.Safari.SearchHelper/11601.6.11 CFNetwork/760.5.1 Darwin/15.5.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.11.5
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/10600.3.18 CFNetwork/720.2.4 Darwin/14.1.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.10.2
+    platform: x64
+    family: Mac
+-
+  user_agent: com.apple.WebKit.WebContent/10600.5.17 CFNetwork/720.3.13 Darwin/14.3.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.10.3
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/10600.7.12 CFNetwork/720.4.4 Darwin/14.4.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.10.4
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/10603.3.8 CFNetwork/720.5.7 Darwin/14.5.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.10.5
+    platform: x64
+    family: Mac
+-
+  user_agent: 'Safari/9537.74.9 CFNetwork/673.2.1 Darwin/13.1.0 (x86_64) (iMac14%2C1)'
+  os:
+    name: Mac
+    version: 10.9.2
+    platform: x64
+    family: Mac
+-
+  user_agent: Sleipnir/4.5.1 CFNetwork/673.3 Darwin/13.2.0 (x86_64) (MacBookPro11,1)
+  os:
+    name: Mac
+    version: 10.9.3
+    platform: x64
+    family: Mac
+-
+  user_agent: 'Bloodhound/2.1 CFNetwork/673.4 Darwin/13.3.0 (x86_64) (MacBookPro10%2C1)'
+  os:
+    name: Mac
+    version: 10.9.4
+    platform: x64
+    family: Mac
+-
+  user_agent: 'Reeder/1010.79.00 CFNetwork/596.1 Darwin/12.1.0 (x86_64) (Macmini5%2C2)'
+  os:
+    name: Mac
+    version: 10.8.1
+    platform: x64
+    family: Mac
+-
+  user_agent: 'Reeder/1010.79.00 CFNetwork/596.2.3 Darwin/12.2.0 (x86_64) (MacBookAir4%2C2)'
+  os:
+    name: Mac
+    version: 10.8.2
+    platform: x64
+    family: Mac
+-
+  user_agent: iCab/5.8.3 CFNetwork/596.3.3 Darwin/12.3.0 (x86_64) (MacBookPro6,2)
+  os:
+    name: Mac
+    version: 10.8.3
+    platform: x64
+    family: Mac
+-
+  user_agent: 'Sparrow/1178 CFNetwork/596.4.3 Darwin/12.4.0 (x86_64) (MacBookPro8%2C2)'
+  os:
+    name: Mac
+    version: 10.8.4
+    platform: x64
+    family: Mac
+-
+  user_agent: 'Safari/8536.30.1 CFNetwork/596.5 Darwin/12.5.0 (x86_64) (iMac13%2C1)'
+  os:
+    name: Mac
+    version: 10.8.5
+    platform: x64
+    family: Mac
+-
+  user_agent: 'CoverScout%203/3.4.4 CFNetwork/520.0.13 Darwin/11.1.0 (x86_64) (MacBookAir3%2C2)'
+  os:
+    name: Mac
+    version: 10.7.1
+    platform: x64
+    family: Mac
+-
+  user_agent: 'Safari/7534.51.22 CFNetwork/520.2.5 Darwin/11.2.0 (x86_64) (MacBookAir4%2C1)'
+  os:
+    name: Mac
+    version: 10.7.2
+    platform: x64
+    family: Mac
+-
+  user_agent: 'Safari/7534.53.10 CFNetwork/520.3.2 Darwin/11.3.0 (x86_64) (Macmini4%2C1)'
+  os:
+    name: Mac
+    version: 10.7.3
+    platform: x64
+    family: Mac
+-
+  user_agent: 'WebProcess/7534.57.2 CFNetwork/520.4.3 Darwin/11.4.0 (x86_64) (MacBookPro5%2C4)'
+  os:
+    name: Mac
+    version: 10.7.4
+    platform: x64
+    family: Mac
+-
+  user_agent: 'WebProcess/7534.57.2 CFNetwork/520.4.3 Darwin/11.5.0 (x86_64) (MacBookPro5%2C4)'
+  os:
+    name: Mac
+    version: 10.7.5
+    platform: x64
+    family: Mac
+-
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36 HbbTV/1.5.1 (+DRM; LGE; WEBOS6.0; WEBOS6.0 00.00.00; W60_O20N; DTV_W21O;)
+  os:
+    name: webOS
+    version: "6.0"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (X11; CrOS aarch64 13310.93.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.133 Safari/537.36
+  os:
+    name: Chrome OS
+    version: 13310.93.0
+    platform: ARM
+    family: Chrome OS
+-
+  user_agent: AppleCoreMedia/1.0.0.17J586 (Apple TV; U; CPU OS 13_0 like Mac OS X; nb_no)
+  os:
+    name: tvOS
+    version: "13.0"
+    platform: ARM
+    family: iOS
+-
+  user_agent: atc/1.0 watchOS/6.0 model/Watch4,2 hwp/t8006 build/17R575 (6; dt:191)
+  os:
+    name: watchOS
+    version: "6.0"
+    platform: ARM
+    family: iOS
+-
+  user_agent: Watch1,1/4.3.2 (15U70)
+  os:
+    name: watchOS
+    version: 4.3.2
+    platform: ARM
+    family: iOS
+-
+  user_agent: Watch1,2/4.3.2 (15U70)
+  os:
+    name: watchOS
+    version: 4.3.2
+    platform: ARM
+    family: iOS
+-
+  user_agent: 'server-bag [Watch OS,4.3.2,15U70,Watch1,2]'
+  os:
+    name: watchOS
+    version: 4.3.2
+    platform: ARM
+    family: iOS
+-
+  user_agent: BBCNewsUKWatchApp/4.3.0 (Watch1,2; watchOS 3.2.2)
+  os:
+    name: watchOS
+    version: 3.2.2
+    platform: ARM
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Apple TV; U; CPU iPhone OS 10_1_1 like Mac OS X; en-US) FOX Sports GO/1160
+  os:
+    name: tvOS
+    version: 10.1.1
+    platform: ARM
+    family: iOS
+-
+  user_agent: H443NM7F8H.CBSSportsApp/1.0 iOS/9.0 model/AppleTV5,3 build/13T393
+  os:
+    name: tvOS
+    version: "9.0"
+    platform: ARM
+    family: iOS
+-
+  user_agent: CBS_Sports;AppleTV;H443NM7F8H.CBSSportsApp/1.0 iOS/9.0 AppleTV/9.0 model/AppleTV5,3 hwp/t7000 build/13T5379f (3; dt:119)
+  os:
+    name: tvOS
+    version: "9.0"
+    platform: ARM
+    family: iOS
+-
+  user_agent: 'Mozilla/5.0 (Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36 OPR/36.0.2128.0 OMI/4.8.0.129.Driver6.39 , _TV_MT5806/201.002.048.000 (Philips, PUS78051, wireless)  CE-HTML/1.0 NETTV/4.6.0.2 SignOn/2.0 SmartTvA/5.0.0 WH1.0 en'
+  os:
+    name: Whale OS
+    version: "1.0"
+    platform: ARM
+    family: Other Smart TV
+-
+  user_agent: 'Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36 OPR/46.0.2207.0 Model/<Model Name>(<Brand>;<CTN>;<SW>_<SW version>;<Platform Name>) SignOn/2.0 WhaleTV/2.0 <language code>'
+  os:
+    name: Whale OS
+    version: "2.0"
+    platform: ARM
+    family: Other Smart TV
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; FydeOS Android) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4128.0 Safari/537.36
+  os:
+    name: FydeOS
+    version: ""
+    platform: ""
+    family: Chrome OS
+-
+  user_agent: Mozilla/5.0 (X11; Linux x8664) AppleWebKit/537.36 (KHTML like Gecko) Chrome/36.0.1985.143 Safari/537.36
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Mageia; Linux x86_64; rv:10.0.9) Gecko/20100101 Firefox/10.0.9
+  os:
+    name: Mageia
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: '[FBAN/MessengerForiOS;FBAV/252.1.0.30.119;FBBV/198832146;FBDV/iPhone9,4;FBMD/iPhone;FBSN/iOS;FBSV/13.3.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5]'
+  os:
+    name: iOS
+    version: 13.3.1
+    platform: ""
+    family: iOS
+-
+  user_agent: 'LightSpeed [FBAN/MessengerLiteForiOS;FBAV/255.0.0.30.124;FBBV/ 202164847;FBDV/iPhone10,4;FBMD/iPhone;FBSN/iOS;FBSV/ 13.3.1;FBSS/2;FBCR/;FBID/phone;FBLC/en_US;FBOP/0]'
+  os:
+    name: iOS
+    version: 13.3.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; U; Mac OSX; it; rv:1.9.0.7) Gecko/2009030422 Firefox/3.0.7
+  os:
+    name: Mac
+    version: ""
+    platform: ""
+    family: Mac
+-
+  user_agent: Biyubi/5.0 (Sistema Fenix; G11; Familia Toledo; es-mx)
+  os:
+    name: Fenix
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Biyubi/4.5 (WinFenix; G11; Familia Toledo; MX)
+  os:
+    name: Fenix
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (WebOS; Linux/SmartTV) AppleWebKit/537.36 (KHTML, likeGecko) Chrome/53.0.2785.34 Safari/537.36 HbbTV/1.4.1 ( DRM; LGE; 43UM71007LB; WEBOS4.5 03.50.90; W45_K5LP; DTV_W19P;)
+  os:
+    name: webOS
+    version: "4.5"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (Linux; Andr0id 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36 OPR/46.0.2207.0 OMI/4.21.0.273.release HbbTV/1.5.1 ( DRM;Amazon;sophia;unknown;unknown;sophia;) FVC/6.0 (Amazon;sophia;) smarttv_AFTSO001_Build_0019126349446_Chromium_84.0.4147.125
+  os:
+    name: Fire OS
+    version: "7"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Andr0id 9; BRAVIA 4K UR1 Build/PTT1.190515.001.S71) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36 OPR/46.0.2207.0 OMI/4.13.5.431.DIA5HBBTV.185 HbbTV/1.5.1 ( DRM; Sony; KDL-GN5; PKG6.4770.0615EUA; ; com.sony.HE.G3.4K; )
+  os:
+    name: Android TV
+    version: "9"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; Linux armv8l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36 HbbTV/1.5.1 ( DRM; MTC; 2K_Android_TV_V01; V0.24.7.2.M001; MS66830-ZC01-01; Reference_2K19;) FVC/4.0 (MTC; Reference_2K19;)
+  os:
+    name: Android TV
+    version: ""
+    platform: ARM
+    family: Android
+-
+  user_agent: PlacesDll Win32/x4dXIL4zf4fEINN8j7e8GA:c5f40ce19e9659484ed40cba84c12227/3.4.422.8 (Windows Phone OS/8.0; NOKIA:Lumia 625; de-DE)
+  os:
+    name: Windows Phone
+    version: "8.0"
+    platform: x86
+    family: Windows Mobile
+-
+  user_agent: MAMPPRO/6.3.1 macOS/11.0.1
+  os:
+    name: Mac
+    version: 11.0.1
+    platform: ""
+    family: Mac
+-
+  user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr Android4.1.1; en-US; 9300) U2/1.0.0 UCBrowser/9.4.0.460 U2/1.0.0 Mobile
+  os:
+    name: Android
+    version: 4.1.1
+    platform: ""
+    family: Android
+-
+  user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr CANVAS EXTREME EDITION; en-US; Micromax_A92) U2/1.0.0 UCBrowser/8.8.1.359 U2/1.0.0 Mobile
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; Linux armv8l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36 HbbTV/1.5.1 ( DRM; MTC; 4K_Android_TV_V01; 1.001; MS68860-ZC01-01; Reference_2K19;) FVC/4.0 (MTC; Reference_2K19;)
+  os:
+    name: Android TV
+    version: ""
+    platform: ARM
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; Linux armv8l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36 HbbTV/1.5.1 (+DRM; UMC-Sharp; FVP6683;1.0.0.0;1.0.0.0; UMC_2KAndroidTV_2019;UMC_SHARP;) FVC/4.0 (UMC-Sharp; UMC_2KAndroidTV_2019;)
+  os:
+    name: Android TV
+    version: ""
+    platform: ARM
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; Allview_TX1_Quasar 4.0.4; ro-ro; ALLVIEW_TX1_Quasar Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+  os:
+    name: Android
+    version: 4.0.4
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; Cosmote_My_mini_Tab 4.0.4; ro-ro; Cosmote_My_mini_Tab Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+  os:
+    name: Android
+    version: 4.0.4
+    platform: ""
+    family: Android
+-
+  user_agent: Microsoft Office OneNote/16.0.12527.21294 (Windows/10.0; Desktop x86; es-MX; Desktop app; Acer/Aspire SW5-012)
+  os:
+    name: Windows
+    version: "10.0"
+    platform: x86
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android jelly bean 4.2.2; es-co; HUAWEI Y210-0151 Build/HuaweiY210-0151) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+  os:
+    name: Android
+    version: 4.2.2
+    platform: ""
+    family: Android
+-
+  user_agent: Dalvik/1.4.0 (Linux; U; Android Kit Kat 4.4; HUAWEI Y210-0151 Build/HuaweiY210-0151)
+  os:
+    name: Android
+    version: "4.4"
+    platform: ""
+    family: Android
+-
+  user_agent: Dalvik/1.4.0 (Linux; U; Android S.O. Ginger Bread 2.3.7; E15a Sony Xperia x8 Build/3.0.1.A.0.145)
+  os:
+    name: Android
+    version: 2.3.7
+    platform: ""
+    family: Android
+-
+  user_agent: Dalvik/1.6.0 (Linux; U; Android The FireCyano 4.0.4; Xperia U Build/IMM76L)
+  os:
+    name: Android
+    version: 4.0.4
+    platform: ""
+    family: Android
+-
+  user_agent: 'Dalvik/1.6.0 (Linux; U; Android Ice Bean: 4.3 / Android: 4.0.4'
+  os:
+    name: Android
+    version: 4.0.4
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; CaixaMagica; Linux x86_64; rv:26.0) Gecko/20100101 Firefox/26.0
+  os:
+    name: Caixa Mágica
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: com.google.GoogleMobile/99.0 iPad/13.4 hw/iPad7_5
+  os:
+    name: iPadOS
+    version: "13.4"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPad; CPU OS 14_2_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Mobile/15E148 Safari/604.1
+  os:
+    name: iPadOS
+    version: 14.2.2
+    platform: ""
+    family: iOS
+-
+  user_agent: Microsoft Office Word/2.44.1211 (iOS/14.0; Tablet; es-MX; AppStore; Apple/iPad11,6)
+  os:
+    name: iPadOS
+    version: "14.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: 'LightSpeed [FBAN/MessengerLiteForiOS;FBAV/270.1.0.54.119;FBBV/225524353;FBDV/iPad7,5;FBMD/iPad;FBSN/iOS;FBSV/13.5.1;FBSS/2;FBCR/;FBID/tablet;FBLC/es_ES;FBOP/0]'
+  os:
+    name: iPadOS
+    version: 13.5.1
+    platform: ""
+    family: iOS
+-
+  user_agent: '[FBAN/FB4A;FBAV/72.0.0.22.69;FBBV/27550279;FBDM/{density=2.0,width=720,height=1280};FBLC/pt_BR;FBCR/Vivo;FBMF/Android;FBBD/Android;FBPN/com.facebook.katana;FBDV/J7 Prime;FBSV/6.1;FBOP/1;FBCA/armeabi-v7a:armeabi;]'
+  os:
+    name: Android
+    version: "6.1"
+    platform: ARM
+    family: Android
+-
+  user_agent: '[FBAN/Orca-Android;FBAV/215.1.0.21.101;FBPN/com.facebook.orca;FBLC/en_GB;FBBV/154685928;FBCR/Banglalink;FBMF/Xiaomi;FBBD/xiaomi;FBDV/Redmi Note 5;FBSV/8.1.0;FBCA/armeabi-v7a:armeabi;FBDM/{density=2.75,width=1080,height=2030};FB_FW/1;]'
+  os:
+    name: Android
+    version: 8.1.0
+    platform: ARM
+    family: Android
+-
+  user_agent: '[FBAN/FBIOS;FBAV/26.0.0.11.13;FBBV/7806348;FBDV/iPhone5,2;FBMD/hone;FBSN/iPhone OS;FBSV/8.1;FBSS/2; FBCR/3DK;FBID/phone;FBLC/da_DK;FBOP/5]'
+  os:
+    name: iOS
+    version: "8.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: com.google.Maps/5.51.0 iSL/3.3 iPhone/13.6 hw/iPhone11_8 (gzip),gzip(gfe)
+  os:
+    name: iOS
+    version: "13.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: Linux UPnP/1.0 Sonos/50.1-65071 (ACR_:samsung:dreamqltevl:SM-G950W)
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Linux UPnP/1.0 Sonos/29.3-87071 (ICRU_iPhone7,1); iOS/Version 8.2 (Build 12D508)
+  os:
+    name: iOS
+    version: "8.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36 Helio/0.98.0
+  os:
+    name: Lumin OS
+    version: 0.98.0
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; HasCodingOs 1.0; Linux x64) AppleWebKit/637.36 (KHTML, like Gecko) Chrome/70.0.3112.101 Safari/637.36 HasBrowser/5.0
+  os:
+    name: HasCodingOS
+    version: "1.0"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux; U; Grid OS 1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Version/5.0 Safari/533.1
+  os:
+    name: GridOS
+    version: "1.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64; Debian/9; Deepin/15.11) Blink AppleWebKit/537.36 (KHTML, like Gecko) Chromium/78.0.3904.108 (Chrome/78.0.3904.108, Safari/537.36) QIHU 360SE/12.2.1070.0
+  os:
+    name: Deepin
+    version: "15.11"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) dvkbuntu-easy-menu/1.0.0 Chrome/83.0.4103.64 Electron/9.0.0 Safari/537.36
+  os:
+    name: DVKBuntu
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1.12) Gecko/20080208 PCLinuxOS/2.0.0.12-1pclos2007 (2007) Firefox/2.0.0.12
+  os:
+    name: PCLinuxOS
+    version: 2.0.0.12
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Wget/1.19.4 (mingw32)
+  os:
+    name: Windows
+    version: ""
+    platform: ""
+    family: Windows
+-
+  user_agent: Wget/1.20.3 (darwin16.7.0)
+  os:
+    name: Mac
+    version: 10.12.6
+    platform: ""
+    family: Mac
+-
+  user_agent: 'Mozilla/5.0 (osmeta like iPhone; U; osmeta 8.3.31975207; RM-1116_15357) AppleWebKit/602.1.1 (KHTML, like Gecko) Mobile/31975207 [FBAN/MessengerForWinPhone;FBAV/75.0.0.28.70;FBBV/31986830;FBRV/0;FBDV/WindowsPhone;FBMD/RM-1116_15357;FBSN/Windows Phone;FBSV/10.0.14364.0;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/45]'
+  os:
+    name: Windows Phone
+    version: 10.0.14364.0
+    platform: ""
+    family: Windows Mobile
+-
+  user_agent: curl/7.21.4 (x86_64-apple-darwin12.2.0) libcurl/7.21.4 OpenSSL/0.9.8x zlib/1.2.5 libidn/1.20
+  os:
+    name: Mac
+    version: 10.8.2
+    platform: x64
+    family: Mac
+-
+  user_agent: Mozilla/5.0 (iPod; U; CPU iPhone OS 421 like Mac OS X; fy-DE) AppleWebKit/533.17.9 (KHTML like Gecko) Mobile/8C148 iPod41 BingWeb/3.02.1641.20120106
+  os:
+    name: iOS
+    version: 4.2.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Opera/9.80 (iOS; Opera Mini/7.0.73345/28.2555; U; ru) Presto/2.10.229 Version/11.62
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: Opera/9.80 (Android; Opera Mini/7.5.54678/28.2555; U; ru) Presto/2.10.289 Version/12.02
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1237 Darwin/20.4.0
+  os:
+    name: iOS
+    version: "14.5"
+    platform: ""
+    family: iOS
+-
+  user_agent: 'Opera%20Touch/77 CFNetwork/1220.1 Darwin/20.3.0'
+  os:
+    name: iOS
+    version: "14.4"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileIron/12.11.12.6 CFNetwork/1240.0.4 Darwin/20.5.0
+  os:
+    name: iOS
+    version: "14.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: Podcasts/1570.6 CFNetwork/1240.0.4 Darwin/20.6.0
+  os:
+    name: iOS
+    version: "14.7"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/1286 Darwin/21.0.0
+  os:
+    name: iOS
+    version: "15.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; HarmonyOS; TAS-AL00; HMSCore 6.0.1.306) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.93 HuaweiBrowser/11.1.2.301 Mobile Safari/537.36
+  os:
+    name: HarmonyOS
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.22371/28.3782; U; en) Presto/2.8.119 Version/11.10
+  os:
+    name: Java ME
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: Mozilla/4.0 (REX; U; en-us; Sanyo; SCP-6750/US; NetFront/3.4/AMB)
+  os:
+    name: REX
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: Wireshark/3.4.9 WinSparkle/0.5.7 (Win64)
+  os:
+    name: Windows
+    version: ""
+    platform: x64
+    family: Windows
+-
+  user_agent: uclient-fetch
+  os:
+    name: OpenWrt
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Roku/DVP-9.10 (509.10E04111A)
+  os:
+    name: Roku OS
+    version: "9.10"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (QSP; Roku; UI; 5.3.0.49)
+  os:
+    name: Roku OS
+    version: 5.3.0.49
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (QSP; Roku; AP; 6.2.80.2752)
+  os:
+    name: Roku OS
+    version: 6.2.80.2752
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: RokuOS/9.4.0.4200, Ignition X/11.8.2021022414, Roku
+  os:
+    name: Roku OS
+    version: 9.4.0.4200
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Roku/Pluto-9.40 (069.40E04200A) v5.3.4
+  os:
+    name: Roku OS
+    version: "9.40"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: GooglePodcasts/2.0.2 iPod_touch/13.4.1 hw/iPod9_1
+  os:
+    name: iOS
+    version: 13.4.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Microsoft-CryptoAPI/10.0
+  os:
+    name: Windows
+    version: "10.0"
+    platform: ""
+    family: Windows
+-
+  user_agent: Microsoft-Delivery-Optimization/10.0
+  os:
+    name: Windows
+    version: "10.0"
+    platform: ""
+    family: Windows
+-
+  user_agent: Windows-Update-Agent/10.0.10011.16384 Client-Protocol/2.32
+  os:
+    name: Windows
+    version: "10.0"
+    platform: ""
+    family: Windows
+-
+  user_agent: MSDW
+  os:
+    name: Windows
+    version: ""
+    platform: ""
+    family: Windows
+-
+  user_agent: HandBrake Win Upd 1.4.2 2021100300
+  os:
+    name: Windows
+    version: ""
+    platform: ""
+    family: Windows
+-
+  user_agent: RubyBrowser/46.3.30 (iPad; iOS 15.0.2; Scale/2.00)
+  os:
+    name: iPadOS
+    version: 15.0.2
+    platform: ""
+    family: iOS
+-
+  user_agent: ActionExtension/185 CFNetwork/1325.0.1 Darwin/21.1.0
+  os:
+    name: iOS
+    version: "15.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: VivaFm/1.21 CFNetwork/1327.0.1 Darwin/21.2.0
+  os:
+    name: iOS
+    version: "15.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: Word/16.50.21061301 CFNetwork/1220.1 Darwin/20.3.0 (x86_64)
+  os:
+    name: Mac
+    version: "11.2"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/16611.1.21.161.6 CFNetwork/1237 Darwin/20.4.0 (x86_64)
+  os:
+    name: Mac
+    version: "11.3"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/16611.2.7.1.4 CFNetwork/1240.0.4 Darwin/20.5.0 (x86_64)
+  os:
+    name: Mac
+    version: "11.4"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/16611.3.10.1.3 CFNetwork/1240.0.4 Darwin/20.6.0 (x86_64)
+  os:
+    name: Mac
+    version: "11.5"
+    platform: x64
+    family: Mac
+-
+  user_agent: Empresarial/6.28.1.8 CFNetwork/1312 Darwin/21.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "12.0"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/17612.2.9.1.20 CFNetwork/1325.0.1 Darwin/21.1.0 (x86_64)
+  os:
+    name: Mac
+    version: 12.0.1
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/17612.2.9.1.20 CFNetwork/1327.0.1 Darwin/21.2.0 (x86_64)
+  os:
+    name: Mac
+    version: "12.1"
+    platform: x64
+    family: Mac
+-
+  user_agent: 'server-bag [iPhone OS,15.1,19B74,iPad11,6]'
+  os:
+    name: iPadOS
+    version: "15.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: 'server-bag [iPhone OS,14.4.2,18D70,iPhone12,3]'
+  os:
+    name: iOS
+    version: 14.4.2
+    platform: ""
+    family: iOS
+-
+  user_agent: 'server-bag [Mac OS X,10.14.6,18G8022,MacBookPro15,4]'
+  os:
+    name: Mac
+    version: 10.14.6
+    platform: ""
+    family: Mac
+-
+  user_agent: A/8.0.0/samsung/SM-A920F/sdm660/unknown/QCX3/l6940188856470205360/35213410/1560275135/234|30 234|30/samsung/556106/556096/-/2.5/1/W
+  os:
+    name: Android
+    version: 8.0.0
+    platform: ""
+    family: Android
+-
+  user_agent: MacOutlook/16.46.21021202 (Intelx64 Mac OS X 11.2.2 (Build 20D80))
+  os:
+    name: Mac
+    version: 11.2.2
+    platform: x64
+    family: Mac
+-
+  user_agent: rekordbox/5.8.6.0004 Windows 10(64bit)
+  os:
+    name: Windows
+    version: "10"
+    platform: x64
+    family: Windows
+-
+  user_agent: Google Update/1.3.36.112;winhttp
+  os:
+    name: Windows
+    version: ""
+    platform: ""
+    family: Windows
+-
+  user_agent: Microsoft-WNS/10.0
+  os:
+    name: Windows
+    version: "10.0"
+    platform: ""
+    family: Windows
+-
+  user_agent: Microsoft BITS/7.8
+  os:
+    name: Windows
+    version: ""
+    platform: ""
+    family: Windows
+-
+  user_agent: 'ERA Agent Update (Windows; U; 64bit; BPC 8.0.1238.0; OS: 10.0.19042 SP 0.0 NT; x64c; APP era; HWF: 0100CC8A-BE80-F512-E058-0DE202DAC0CB; PLOC en_US; PCODE 901.0.0; PX 0)'
+  os:
+    name: Windows
+    version: 10.0.19042
+    platform: x64
+    family: Windows
+-
+  user_agent: 'NGC/22.21.9.25 MID/{00000000-0000-0000-0000-000000000000} SID/BU2KYQAAAAA LUE/1.17.0.4 (Windows;10.0;SP0.0;X64;en-GB)'
+  os:
+    name: Windows
+    version: "10.0"
+    platform: x64
+    family: Windows
+-
+  user_agent: Microsoft-WebDAV-MiniRedir/10.0.19042
+  os:
+    name: Windows
+    version: "10.0"
+    platform: ""
+    family: Windows
+-
+  user_agent: iPad5,3/14.8 (18H17)
+  os:
+    name: iPadOS
+    version: "14.8"
+    platform: ""
+    family: iOS
+-
+  user_agent: iPad4,7/12.5.1 (16H22)
+  os:
+    name: iOS
+    version: 12.5.1
+    platform: ""
+    family: iOS
+-
+  user_agent: iPhone7,2/12.5.5 (16H62)
+  os:
+    name: iOS
+    version: 12.5.5
+    platform: ""
+    family: iOS
+-
+  user_agent: CreativeCloud/5.6.0.788/Mac-11.4
+  os:
+    name: Mac
+    version: "11.4"
+    platform: ""
+    family: Mac
+-
+  user_agent: 'server-bag [macOS,11.6.1,20G224,MacBookAir6,2]'
+  os:
+    name: Mac
+    version: 11.6.1
+    platform: ""
+    family: Mac
+-
+  user_agent: AppleExchangeWebServices/818.0.1 Mail/3693.20.0.1.32
+  os:
+    name: Mac
+    version: ""
+    platform: ""
+    family: Mac
+-
+  user_agent: com.apple.trustd/2.0
+  os:
+    name: Mac
+    version: ""
+    platform: ""
+    family: Mac
+-
+  user_agent: Bookshelf-Android/10.0.3 (Android OS/9; Samsung Chromebook 3) vitalsource
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+-
+  user_agent: 'server-bag [iPhone OS,10.3.2,14F89,iPod7,1]'
+  os:
+    name: iOS
+    version: 10.3.2
+    platform: ""
+    family: iOS
+-
+  user_agent: CaptiveNetworkSupport-416 wispr
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: 'Gibbon/2020.2.2.0/2020.2.2.0: Netflix/2020.2.2.0 (DEVTYPE=NFANDROID2-PRV-FIRETVSTICK2018; CERTVER=0)'
+  os:
+    name: Fire OS
+    version: "6"
+    platform: ""
+    family: Android
+-
+  user_agent: Jungle Disk Workgroup HTTP/110 (Windows 10.0 64-bit)
+  os:
+    name: Windows
+    version: "10"
+    platform: x64
+    family: Windows
+-
+  user_agent: GOGGalaxyCommunicationService/2.0.4.164 (Windows_32bit)
+  os:
+    name: Windows
+    version: ""
+    platform: x86
+    family: Windows
+-
+  user_agent: Hola svc_js_win32/1.187.344
+  os:
+    name: Windows
+    version: ""
+    platform: x86
+    family: Windows
+-
+  user_agent: Deezer/8.51.0.5 (iOS; 14.4.2; Mobile; en; iPhone10_4)
+  os:
+    name: iOS
+    version: 14.4.2
+    platform: ""
+    family: iOS
+-
+  user_agent: iPhone12,1_15.0.2_weibo_11.10.1_iPhone_wifi ijkplayer WBFPlayer
+  os:
+    name: iOS
+    version: 15.0.2
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/601.1 CFNetwork/758.5.3 Darwin/15.6.0
+  os:
+    name: iOS
+    version: 9.3.5
+    platform: ""
+    family: iOS
+-
+  user_agent: Puffin/16015 CFNetwork/893.14.2 Darwin/17.3.0
+  os:
+    name: iOS
+    version: "11.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: MobileSafari/604.1 CFNetwork/894 Darwin/17.4.0
+  os:
+    name: iOS
+    version: 11.2.6
+    platform: ""
+    family: iOS
+-
+  user_agent: Puffin/15867 CFNetwork/897.15 Darwin/17.5.0
+  os:
+    name: iOS
+    version: "11.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: iPhoneOS/12.1.4 (16D57)
+  os:
+    name: iOS
+    version: 12.1.4
+    platform: ""
+    family: iOS
+-
+  user_agent: 'server-bag [iPhone OS,12.4.8,16G201,iPad4,4]'
+  os:
+    name: iOS
+    version: 12.4.8
+    platform: ""
+    family: iOS
+-
+  user_agent: Rokt SDK(iPhone; ios Version/13.1.1)
+  os:
+    name: iOS
+    version: 13.1.1
+    platform: ""
+    family: iOS
+-
+  user_agent: gamed/5.11.20.4.9.17.5.5.2 (iPad4,4; 12.4.8; 16G201; GameKit-577.8)
+  os:
+    name: iOS
+    version: 12.4.8
+    platform: ""
+    family: iOS
+-
+  user_agent: iPhone7,1; Version 12.4.6 (Build 16G183); com.apple.ap.adprivacyd; 143441-1,29
+  os:
+    name: iOS
+    version: 12.4.6
+    platform: ""
+    family: iOS
+-
+  user_agent: Safari5533.22.3 CFNetwork/438.16 Darwin/9.8.0 (Power Macintosh) (PowerMac7,2)
+  os:
+    name: Mac
+    version: 10.5.8
+    platform: ""
+    family: Mac
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android Marshmallow; en-us; A7+ Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36 PHX/6.8
+  os:
+    name: Android
+    version: "6"
+    platform: ""
+    family: Android
+-
+  user_agent: AirPlay/540.31
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (AppleTV11,1; CPU OS 11.1 like Mac OS X; en-US)
+  os:
+    name: tvOS
+    version: "11.1"
+    platform: ARM
+    family: iOS
+-
+  user_agent: RokuOS/3.0.0|Roku 3930X|STB|RokuOS 9.4.0 4200
+  os:
+    name: Roku OS
+    version: 9.4.0
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: com.apple.Safari.SearchHelper/14607.1.40.1.4 CFNetwork/978.0.7 Darwin/18.5.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.14.4
+    platform: x64
+    family: Mac
+-
+  user_agent: com.apple.Safari.SearchHelper/14607.2.6.1.1 CFNetwork/978.0.7 Darwin/18.6.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.14.5
+    platform: x64
+    family: Mac
+-
+  user_agent: com.apple.Safari.SearchHelper/12602.1.50.0.2 CFNetwork/807.0.4 Darwin/16.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.12"
+    platform: x64
+    family: Mac
+-
+  user_agent: iTunes/12.9.5 (Macintosh; OS X 10.14.6) AppleWebKit/607.3.9
+  os:
+    name: Mac
+    version: 10.14.6
+    platform: ""
+    family: Mac
+-
+  user_agent: Safari/10600.1.25 CFNetwork/720.0.7 Darwin/14.0.0 (x86_64)
+  os:
+    name: Mac
+    version: "10.10"
+    platform: x64
+    family: Mac
+-
+  user_agent: Safari/12602.4.8 CFNetwork/807.2.14 Darwin/16.4.0 (x86_64)
+  os:
+    name: Mac
+    version: 10.12.3
+    platform: x64
+    family: Mac
+-
+  user_agent: 'Safari/6531.9 CFNetwork/454.4 Darwin/10.0.0 (i386) (MacBook4%2C1)'
+  os:
+    name: Mac
+    version: "10.6"
+    platform: x86
+    family: Mac
+-
+  user_agent: 'Safari/8537.85.17.9.1 CFNetwork/596.6.4 Darwin/12.6.0 (x86_64) (iMac13%2C2)'
+  os:
+    name: Mac
+    version: 10.8.5
+    platform: x64
+    family: Mac
+-
+  user_agent: 'Safari/6533.21.1 CFNetwork/454.11.12 Darwin/10.7.4 (x86_64) (MacBookPro8%2C1)'
+  os:
+    name: Mac
+    version: 10.6.7
+    platform: x64
+    family: Mac
+-
+  user_agent: GoogleEarth/4.2.0205.5730(Macintosh;Mac OS X (10.5.4);en;kml:2.2;client:Free;type:default)
+  os:
+    name: Mac
+    version: 10.5.4
+    platform: ""
+    family: Mac
+-
+  user_agent: GoogleEarth/7.0.3.8542(Windows;Microsoft Windows (6.1.7601.1);pt;kml:2.2;client:Free;type:default)
+  os:
+    name: Windows
+    version: "7"
+    platform: ""
+    family: Windows
+-
+  user_agent: Google.DriveExtension/4.2020.46208 (OS=iOS;OSVer=13.6;Manufacturer=Apple;Model=iPhone_11_Pro_Max) gzip
+  os:
+    name: iOS
+    version: "13.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: H10P/com.Nanoteq.QmunicateH10p;os=Apple-iOS;model=iPhone9,3;osversion=13.6/3.1.0 (belle-sip/1.6.1)
+  os:
+    name: iOS
+    version: "13.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: 'FBAV/252.1.0.30.119;FBBV/198832146;FBDV/iPhone10,2;FBMD/iPhone;FBSN/iOS;FBSV/13.3.1;FBSS/3;FBID/phone;FBLC/en_US;FBOP/5]'
+  os:
+    name: iOS
+    version: 13.3.1
+    platform: ""
+    family: iOS
+-
+  user_agent: com.apple.Safari.SearchHelper/16610.2.8.1.1 CFNetwork/1206 Darwin/20.1.0
+  os:
+    name: Mac
+    version: "11.0"
+    platform: ""
+    family: Mac
+-
+  user_agent: 'Safari5533.22.3 CFNetwork/438.16 Darwin/9.8.0 (Power%20Macintosh) (PowerBook6%2C7)'
+  os:
+    name: Mac
+    version: 10.5.8
+    platform: ""
+    family: Mac
+-
+  user_agent: Opera/9.80 (Linux mips; Opera TV/4) Presto/2.11.355 Version/12.11
+  os:
+    name: Opera TV
+    version: ""
+    platform: MIPS
+    family: GNU/Linux
+-
+  user_agent: Opera/9.80 (Linux armv7l; Opera TV Store/5581) Presto/2.12.362 Version/12.11
+  os:
+    name: Opera TV
+    version: ""
+    platform: ARM
+    family: GNU/Linux
+-
+  user_agent: Opera/9.80 (Linux mips) Presto/2.12.407 Version/12.50 , KreaTV/12.36.2.2 (ARRIS, VMS1100, wired)
+  os:
+    name: KreaTV
+    version: 12.36.2.2
+    platform: MIPS
+    family: GNU/Linux
+-
+  user_agent: 'OPR/22.0.1481.0 OMI/4.2.12.29, KreaTV/0.0.0.0 (ARRIS, IPC1100, wired)CM[00.01]'
+  os:
+    name: KreaTV
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Librem 5, like iPhone; X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15 Epiphany/605.1.15
+  os:
+    name: PureOS
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Dalvik/1.6.0 (Linux; U; Android V3 (AOSP 4.0.3); ALCATEL ONE TOUCH FIRE Build/IML74K)
+  os:
+    name: Android
+    version: 4.0.3
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Plasma Mobile, like Android 9.0) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.14.2 Chrome/75.0.3770.116 Mobile Safari/537.36
+  os:
+    name: Plasma Mobile
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (FreeBSD; U; Viera; like Android 4.0.2; xx; ja-jp) AppleWebKit/534.30 (KHTML, like Gecko) Viera/2.0.0 DIGAPlus/1.0.0 Mobile/534.30
+  os:
+    name: FreeBSD
+    version: ""
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (X11; Fuchsia x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3557.0 Safari/537.36
+  os:
+    name: Fuchsia
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1) Gecko/20090619 Pardus/2009 Firefox/3.5
+  os:
+    name: Pardus
+    version: "2009"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en; rv:1.9b5) Gecko Foresight Linux Epiphany/2.22
+  os:
+    name: Foresight Linux
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.12) Gecko/20100826 moonOS/3.0 (Makara) Firefox/3.5.2
+  os:
+    name: moonOS
+    version: "3.0"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: ELinks/0.9.3 (textmode; Linux 2.6.9-kanotix-8 i686; 127x41)
+  os:
+    name: Kanotix
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; de; rv:1.9.2.13) Gecko/20101221 IceCat/3.6.13 (like Firefox/3.6.13) (Zenwalk GNU Linux)
+  os:
+    name: Zenwalk
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (compatible; Konqueror/2.2.2; Linux 2.4.18; X11; i686; AffiliateCashGen/1.0; en) LindowsOS (Lindows.com, Inc.)
+  os:
+    name: LindowsOS
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; nl-NL; rv:1.6) Gecko/20050714 Linspire/1.6-5.1.0.50.linspire2.70
+  os:
+    name: Linspire
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; MStar Android TV Build/LMY47V)
+  os:
+    name: Android TV
+    version: 5.1.1
+    platform: ""
+    family: Android
+-
+  user_agent: dv(iPh11,2);pr(UCBrowser/11.3.5.1203);ov(15_2);ss(375x812);bt(GJ);pm(0);bv(0);nm(0);im(0);nt(1);
+  os:
+    name: iOS
+    version: "15.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: dv(iPh11,2);pr(UCBrowser/11.3.5.1203);ov(15_2_1);ss(375x812);bt(GJ);pm(0);bv(0);nm(0);im(0);nt(1);
+  os:
+    name: iOS
+    version: 15.2.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; CrOS x86_64 14150.90.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.126 Safari/537.36
+  os:
+    name: Chromium OS
+    version: 14150.90.0
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Chromium OS
+    Sec-CH-UA-Platform-Version: 14150.90.0
+    Sec-CH-UA-Arch: x86
+    Sec-CH-UA-Bitness: "64"
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; ClearPHONE 620 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/98.0.4758.101 Mobile Safari/537.36
+  os:
+    name: ClearOS Mobile
+    version: "10"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; COS like Android 4.1.2; zh_CN; 909d Build/JRO03C) AppleWebKit/537.17 (KHTML, like Gecko) COSBrowser/1.0.0 Version/4.0 Mobile Safari/537.17
+  os:
+    name: China OS
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux; Ubuntu 15.04 like Android 4.4) AppleWebKit/537.36 Chromium/35.0.1870.2 Mobile Safari/537.36
+  os:
+    name: Ubuntu
+    version: "15.04"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: curl/7.22.0 (x86_64-pc-linux-gnu) libcurl/7.22.0 OpenSSL/1.0.1 zlib/1.2.3.4 libidn/1.23 librtmp/2.3
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.13.1.0 zlib/1.2.3 libidn/1.18 libssh2/1.2.2
+  os:
+    name: Red Hat
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: curl/7.19.7 (x86_64-unknown-linux-gnu) libcurl/7.19.7 NSS/3.12.7.0 zlib/1.2.3 libidn/1.18 libssh2/1.2.2
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: python-requests/1.2.3 CPython/2.7.12 Linux/4.9.62-21.56.amzn1.x86_64
+  os:
+    name: Amazon Linux
+    version: "1"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: python-requests/2.6.0 CPython/2.7.14 Linux/4.14.51-66.38.amzn2.x86_64
+  os:
+    name: Amazon Linux
+    version: "2"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: python-requests/1.1.0 CPython/2.7.5 Linux/3.10.0-121.el7.x86_64
+  os:
+    name: CentOS
+    version: "7"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: python-requests/2.5.1 CPython/2.7.17 Linux/4.18.0-147.3.1.el8_1.x86_64
+  os:
+    name: CentOS
+    version: "8.1"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: python-requests/2.6.0 CPython/2.7.5 Linux/4.14.105-1-tlinux3-0016
+  os:
+    name: TencentOS
+    version: "3"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; bliss_maple) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.58 Mobile Safari/537.36
+  os:
+    name: Bliss OS
+    version: "12"
+    platform: ""
+    family: Android
+-
+  user_agent: Roku/DVP (297.70E04154A)
+  os:
+    name: Roku OS
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: libdnf (CentOS Stream 8; generic; Linux.x86_64)
+  os:
+    name: CentOS Stream
+    version: "8"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: libdnf (CentOS Stream 9; generic; Linux.x86_64)
+  os:
+    name: CentOS Stream
+    version: "9"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: libdnf (CentOS Linux 8; generic; Linux.x86_64)
+  os:
+    name: CentOS
+    version: "8"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: 'Mozilla/5.0 (iPad; U; CPU OS 5_0 like Mac OS X; en-us) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.0.2 Mobile/9A5248d Safari/6533.18.5#2.0#TCL/TCL-ME-RTD51M-S1/30/tclwebkit1.0.2/1920*1080(590104473,null;227437109,000)'
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+    family: Android
+-
+  user_agent: 'Mozilla/5.0 (iPad; U; CPU OS 5_0 like Mac OS X; en-us) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.0.2 Mobile/9A5248d Safari/6533.18.5#2.0#TCL/TCL-ME-RT95-S1-ME/17/tclwebkit1.0.2/1920*1080(441695831,null;220213472, xxx)'
+  os:
+    name: Android
+    version: "4.2"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; revengeos_x2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
+  os:
+    name: Revenge OS
+    version: "2"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; lineage_ss2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Mobile Safari/537.36 OPR/62.3.3146.57763
+  os:
+    name: Lineage OS
+    version: "18.0"
+    platform: ""
+    family: Android
+-
+  user_agent: 'NGL Client/1.28.0.10 (WINDOWS_64/10.0.19044.1) [2022-04-28T01:01:27.003 0200]'
+  os:
+    name: Windows
+    version: "10.0"
+    platform: x64
+    family: Windows
+-
+  user_agent: Aloha/3 CFNetwork/1333.0.4 Darwin/21.5.0
+  os:
+    name: iOS
+    version: "15.5"
+    platform: ""
+    family: iOS
+-
+  user_agent: aws-sdk-dotnet-45/3.7.1.10 aws-sdk-dotnet-core/3.7.5.13 .NET_Runtime/4.0 .NET_Framework/4.0 OS/Microsoft_Windows_NT_10.0.19044.0 ClientAsync
+  os:
+    name: Windows
+    version: "10.0"
+    platform: ""
+    family: Windows
+-
+  user_agent: Aloha/1 CFNetwork/1335.0.2 Darwin/21.6.0
+  os:
+    name: iOS
+    version: "15.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: Lupa/6 CFNetwork/1378.1 Darwin/22.0.0
+  os:
+    name: iOS
+    version: "16.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; Nova; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0
+  os:
+    name: Nova
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.8.1.11) Gecko/20070914 Mandriva/2.0.0.11-1.1mdv2008.0 (2008.0) Firefox/51.0.1
+  os:
+    name: Mandriva
+    version: "2008.0"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.1.1) Gecko/20090716 Linux Mint/7 (Gloria) Firefox/52.7.0
+  os:
+    name: Mint
+    version: "7"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: "Don't Waste My Time! Extension/1.0 (skavans.dont-waste-my-time.extension; build:2; macOS 10.15.7) Alamofire/5.0.4"
+  os:
+    name: Mac
+    version: 10.15.7
+    platform: ""
+    family: Mac
+-
+  user_agent: Surfshark/3.0.2 ;(Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1);(com.surfshark.vpnclient.ios; build:6; iOS 15.3.1) sshark.app.ios
+  os:
+    name: iOS
+    version: 15.3.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone13,4; CPU iPhone13,4 OS 15_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 YahooMobileSearch/1.0 OneSearch/2.3.2.0
+  os:
+    name: iOS
+    version: 15.3.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Windows NT 6.0; Changhong Andr0id TV Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 SMART-TV
+  os:
+    name: Android TV
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 8.1.0; FINNEY U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.210 Mobile Safari/537.36
+  os:
+    name: Sirin OS
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Mikrotik/6.x Fetch
+  os:
+    name: RouterOS
+    version: "6"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Roku4640X/DVP-7.70 (297.70E04154A)
+  os:
+    name: Roku OS
+    version: "7.70"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: 'Dalvik/2.1.0 (Linux; U; Android 10; AT&T TV Build/QTG1.201103.001)'
+  os:
+    name: Android TV
+    version: "10"
+    platform: ""
+    family: Android
+-
+  user_agent: DDG-Android-3.1.1
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; HarmonyOS; MGA-AL00; HMSCore 6.7.0.302) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.105 HuaweiBrowser/12.1.3.303 Mobile Safari/537.36
+  os:
+    name: HarmonyOS
+    version: ""
+    platform: ""
+    family: Android
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 10; HarmonyOS
+-
+  user_agent: Mozilla/5.0 (X11; Linux i686; Zorin OS 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.0 Maxthon/1.0.5.3 Safari/537.36
+  os:
+    name: ZorinOS
+    version: "9"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux; Android 8.1.0; rr_fortuna3g) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
+  os:
+    name: Resurrection Remix OS
+    version: "6"
+    platform: ""
+    family: Android
+-
+  user_agent: Azul 6.0.1 rv:6.0 (iPad; iPhone OS 15.6.1; en_US)
+  os:
+    name: iPadOS
+    version: 15.6.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64; Quest) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/20.0.0.3.8.358844291 SamsungBrowser/4.0 Chrome/98.0.4758.119 VR Safari/537.36
+  os:
+    name: Meta Horizon
+    version: ""
+    platform: x64
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/22.2.0.3.39.382455783 SamsungBrowser/4.0 Chrome/102.0.5005.148 VR Safari/537.36
+  os:
+    name: Meta Horizon
+    version: ""
+    platform: x64
+    family: Android
+-
+  user_agent: Aloha/1 CFNetwork/1399 Darwin/22.1.0
+  os:
+    name: iOS
+    version: "16.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: Aloha/1 CFNetwork/1402 Darwin/22.2.0
+  os:
+    name: iOS
+    version: "16.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: Aloha/1 CFNetwork/1404 Darwin/22.3.0
+  os:
+    name: iOS
+    version: "16.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: com.apple.Safari.SearchHelper/18614.2.9.1.12 CFNetwork/1399.4 Darwin/22.1.0
+  os:
+    name: Mac
+    version: 13.0.1
+    platform: ""
+    family: Mac
+-
+  user_agent: TuneIn Radio/24.5.0; iPad8,10; iPadOS/16.1.1
+  os:
+    name: iPadOS
+    version: 16.1.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; RED OS; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36 (Chromium GOST)
+  os:
+    name: RedOS
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: TinyTap/4.2.4 (iPad; iPadOS 15.4.1; Scale/2.00)
+  os:
+    name: iPadOS
+    version: 15.4.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.2; AOSP on r33a0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36 EdgA/96.0.1054.53
+  os:
+    name: Android TV
+    version: 7.1.2
+    platform: ""
+    family: Android
+-
+  user_agent: Overcast (+http://overcast.fm/; Apple Watch podcast app)
+  os:
+    name: watchOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; BLM-00 Build/HUAWEIBLM-00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 UWS/3.22.1.228 Mobile Safari/537.36 AliApp(DingTalk/6.5.30) com.alibaba.android.rimet/25293052 Channel/227200 language/zh-CN abi/64 Pad/APad Hmos/1 UT4Aplus/0.2.25 colorScheme/light
+  os:
+    name: HarmonyOS
+    version: 1.0.0
+    platform: ""
+    family: Android
+-
+  user_agent: Safari/18615.1.21.11.5 CFNetwork/1406.0.2 Darwin/22.4.0
+  os:
+    name: Mac
+    version: "13.3"
+    platform: ""
+    family: Mac
+-
+  user_agent: Aloha/1 CFNetwork/1406.0.4 Darwin/22.4.0
+  os:
+    name: iOS
+    version: "16.4"
+    platform: ""
+    family: iOS
+-
+  user_agent: Aloha/1 CFNetwork/1408.0.2 Darwin/22.5.0
+  os:
+    name: iOS
+    version: "16.5"
+    platform: ""
+    family: iOS
+-
+  user_agent: Aloha/1 CFNetwork/1410.0.1 Darwin/22.6.0
+  os:
+    name: iOS
+    version: "16.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: Safari/18615.3.5.11.2 CFNetwork/1410.0.1 Darwin/22.6.0
+  os:
+    name: Mac
+    version: "13.5"
+    platform: ""
+    family: Mac
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 34)
+  os:
+    name: Android
+    version: "14"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 33)
+  os:
+    name: Android
+    version: "13"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 32)
+  os:
+    name: Android
+    version: "12.1"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 31)
+  os:
+    name: Android
+    version: "12"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 30)
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 29)
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 28)
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 27)
+  os:
+    name: Android
+    version: "8.1"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 26)
+  os:
+    name: Android
+    version: "8"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 25)
+  os:
+    name: Android
+    version: "7.1"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 24)
+  os:
+    name: Android
+    version: "7"
+    platform: ""
+    family: Android
+-
+  user_agent: DuckDuckGo/5 (com.duckduckgo.mobile.android; Android API 23)
+  os:
+    name: Android
+    version: "6"
+    platform: ""
+    family: Android
+-
+  user_agent: ddg_android/5.114.3 (com.duckduckgo.mobile.android; Android API 22)
+  os:
+    name: Android
+    version: "5.1"
+    platform: ""
+    family: Android
+-
+  user_agent: otg/1.5.1 (AppleTv Apple TV 4; tvOS16.2; appletv.client) libcurl/7.58.0 OpenSSL/1.0.2o zlib/1.2.11 clib/1.8.56
+  os:
+    name: tvOS
+    version: "16.2"
+    platform: ARM
+    family: iOS
+-
+  user_agent: Dragon/13.13 (BeOS 5.0; ar_LB;)
+  os:
+    name: BeOS
+    version: "5.0"
+    platform: ""
+    family: BeOS
+-
+  user_agent: Opera/20.10 (BeOS 7.7; ar_EG;)
+  os:
+    name: BeOS
+    version: "7.7"
+    platform: ""
+    family: BeOS
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; TicWatch Pro S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Odd/47.2.1.1 Mobile Safari/537.36
+  os:
+    name: Wear OS
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: StudioDisplay/0.5 (Windows; 10; AMD64; 64bit; utf-8)
+  os:
+    name: Windows
+    version: "10"
+    platform: x64
+    family: Windows
+-
+  user_agent: StudioDisplay/0.5 (Darwin; 21.4.0; x86_64; 64bit; utf-8)
+  os:
+    name: Mac
+    version: "12.3"
+    platform: x64
+    family: Mac
+-
+  user_agent: Dalvik/2.1.0 (Linux; U; Android 11; BRAVIA VU31 Build/RTK2.220814.001)
+  os:
+    name: Android TV
+    version: "11"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64; PICO 4 OS5.4.0 like Quest) AppleWebKit/537.36 (KHTML, like Gecko) PicoBrowser/3.3.22 Chrome/105.0.5195.68 VR Safari/537.36 OculusBrowser/7.0
+  os:
+    name: PICO OS
+    version: 5.4.0
+    platform: x64
+    family: Android
+-
+  user_agent: Aloha/1 CFNetwork/1483 Darwin/23.1.0
+  os:
+    name: iOS
+    version: "17.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: Safari/19616.8.27.211.1 CFNetwork/1483 Darwin/23.1.0
+  os:
+    name: Mac
+    version: "14.1"
+    platform: ""
+    family: Mac
+-
+  user_agent: python-requests/2.7.0 CPython/2.7.15 Linux/4.16.0-kali2-amd64
+  os:
+    name: Kali
+    version: "2"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: python-requests/2.6.0 CPython/2.7.5 Linux/4.1.12-124.15.4.el7uek.x86_64
+  os:
+    name: Oracle Linux
+    version: "7"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Odin/88.4324.2.10 Safari/537.36 Model/Hisense-NT72671D VIDAA/6.0(Hisense;SmartTV;85A66GAVT;NT72671/V0000.06.12N.N0622;UHD;86A6GA;)
+  os:
+    name: VIDAA
+    version: "6.0"
+    platform: ARM
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.140 Safari/537.36 OPR/46.0.2207.0 OMI/4.21.2.50.Honey.220 Model/Hisense-NT72671D TV Store/4.21
+  os:
+    name: Opera TV
+    version: "4.21"
+    platform: ARM
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.128 Safari/537.36 OPR/46.0.2207.0 OMI/4.23.2.96.LIMA2.89 Model/Vestel-MB180 VSTVB MB100 FVC/8.0 (OEM; MB180; ) HbbTV/1.6.1 (+DRM; OEM; MB180; 0.32.0.0; ; _TV_G31_2023;) TiVoOS/1.0.0 (Vestel MB180 OEM) SmartTvA/3.0.0
+  os:
+    name: TiVo OS
+    version: 1.0.0
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Aloha/1 CFNetwork/1490.0.1 Darwin/23.2.0
+  os:
+    name: iOS
+    version: "17.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: RokuBrowser/84.42.14 (TV-G000X-12.5.0.4176) Chrome/84.0.4147.38 HbbTV/1.6.1 (+DRM; SHARP; 50FJ2E; 12.5.0.4176-84.42.14; ; com.roku.G000X; )
+  os:
+    name: Roku OS
+    version: 12.5.0.4176
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux; Andr0id 9; AFTBOXE1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.59 Safari/537.36 OPR/46.0.2207.0 OMI/4.23.2.73.AFTdev.465 HbbTV/1.5.1 (+DRM;Amazon;AFTBOXE1-TOSHIBA-65UF3D63DA;0024126536068;unknown;com.amazon.m7632;) smarttv_AFTBOXE1-TOSHIBA-65UF3D63DA_Build_0024126536068_Chromium_108.0.5359.59
+  os:
+    name: Fire OS
+    version: "7"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (LuneOS, like webOS/3.0.5; Tablet) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.9.2 Chrome/56.0.2924.103 Safari/537.36
+  os:
+    name: LuneOS
+    version: ""
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.2; AFTBU001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+  os:
+    name: Fire OS
+    version: "6"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; AFTKRT Build/RS8101.1854N; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/112.0.5615.197 Mobile Safari/537.36 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0
+  os:
+    name: Fire OS
+    version: "8"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; KFMAWI Build/PS7327.3329N; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/112.0.5615.197 Mobile Safari/537.36 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0
+  os:
+    name: Fire OS
+    version: "7"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; en-US; KFSUWI Build/LVY48F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.3.1204 Mobile Safari/537.36
+  os:
+    name: Fire OS
+    version: "5"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; KFQUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.5.2 like Chrome/94.0.4606.128 Safari/537.36
+  os:
+    name: Fire OS
+    version: "8"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.2; KFMUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.4.14 like Chrome/80.0.3987.119 Safari/537.36
+  os:
+    name: Fire OS
+    version: "6"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; KFTT Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+  os:
+    name: Fire OS
+    version: "3"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 4.2.2; KFAPWI Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
+  os:
+    name: Fire OS
+    version: "3"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 4.0.4; KFJWA Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.42 Safari/537.36
+  os:
+    name: Fire OS
+    version: "3"
+    platform: ""
+    family: Android
+-
+  user_agent: AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36 HbbTV/1.5.1 (+DRM; UMC-Sharp; FVP6886;1.0.0.0;1.0.0.0; UMC_GoogleTV_2019;UMC_SHARP;) FVC/4.0 (UMC; UMC_GoogleTV_2019;)
+  os:
+    name: Android TV
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36 HbbTV/1.5.1 (+DRM;UMC-Sharp; FVP9685;1.0.0.0; 1.0.0.0;UMC_AndroidTV_2021;UMC_SHARP;) FVC/6.0 (UMC;UMC_AndroidTV_2021;)
+  os:
+    name: Android TV
+    version: ""
+    platform: ARM
+    family: Android
+-
+  user_agent: smarttv_AFTS_Build_565189620_Chromium_34.0.1847.114
+  os:
+    name: Fire OS
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9.0.0; P1 Build/PQ3B.190801.002; wv-atv; mse) Google/1.0.0 AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36
+  os:
+    name: Android TV
+    version: 9.0.0
+    platform: ""
+    family: Android
+-
+  user_agent: Aloha/1 CFNetwork/1492.0.1 Darwin/23.3.0
+  os:
+    name: iOS
+    version: "17.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: Safari/19617.1.17.11.9 CFNetwork/1490.0.4 Darwin/23.2.0
+  os:
+    name: Mac
+    version: "14.2"
+    platform: ""
+    family: Mac
+-
+  user_agent: Safari/19617.2.1.11.3 CFNetwork/1492.0.1 Darwin/23.3.0
+  os:
+    name: Mac
+    version: "14.3"
+    platform: ""
+    family: Mac
+-
+  user_agent: Aloha/1 CFNetwork/1494.0.5 Darwin/23.4.0
+  os:
+    name: iOS
+    version: "17.4"
+    platform: ""
+    family: iOS
+-
+  user_agent: Safari/19617.7.20.11.12 CFNetwork/1494.0.5 Darwin/23.4.0
+  os:
+    name: Mac
+    version: "14.4"
+    platform: ""
+    family: Mac
+-
+  user_agent: Aloha/1 Mana/0.0.1 Darwin/21.0.0
+  os:
+    name: iOS
+    version: "15.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: BrightSign/8.3.23 (XT1144) Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.12.3 Chrome/69.0.3497.128 Safari/537.36
+  os:
+    name: BrightSignOS
+    version: 8.3.23
+    platform: ARM
+    family: GNU/Linux
+-
+  user_agent: BrightSign/35D6AA000662/6.2.80.1 (HD1023) Mozilla/5.0 (Unknown; Linux arm) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.6.0 Chrome/45.0.2454.101 Safari/537.36
+  os:
+    name: BrightSignOS
+    version: 6.2.80.1
+    platform: ARM
+    family: GNU/Linux
+-
+  user_agent: Callpod Keeper for Android 1.0 (10.5.6/270) Dalvik/2.1.0 (Linux; U; Android 13; SM-S908B Build/TP1A.220624.014)
+  os:
+    name: Android
+    version: "13"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (iPad; CPU iPad OS 17_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
+  os:
+    name: iPadOS
+    version: 17.1.2
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPad; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Version/14.6 Safari/605.1.15 AlohaBrowser/3.4.1
+  os:
+    name: iPadOS
+    version: "14.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Macintosh; ARM Mac OS X) AppleWebKit/538.15 (KHTML, like Gecko) Safari/538.15 Version/6.0 Raspbian/8.0 (1:3.8.2.0-0rpi27rpi1g) Epiphany/3.8.2
+  os:
+    name: Raspbian
+    version: "8.0"
+    platform: ARM
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Macintosh; ARM Mac OS X) AppleWebKit/538.15 (KHTML, like Gecko) Safari/538.15 Version/6.0 Raspbian/9.0 (1:3.8.2.0-0rpi28) Epiphany/3.8.2
+  os:
+    name: Raspbian
+    version: "9.0"
+    platform: ARM
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Raspbian Chromium/72.0.3626.121 Chrome/72.0.3626.121 Safari/537.36
+  os:
+    name: Raspberry Pi OS
+    version: ""
+    platform: ARM
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36 UOS
+  os:
+    name: UOS
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: 'Mozilla/5.0 (X11; Linux x86_64; PICO 4 OS5.4.0 like Quest) AppleWebKit/537.36 (KHTML, like Gecko) PicoBrowser/3.3.22 Chrome/105.0.5195.68 VR Safari/537.36  OculusBrowser/7.0'
+  os:
+    name: PICO OS
+    version: 5.4.0
+    platform: x64
+    family: Android
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 10.0.0
+-
+  user_agent: WhatsApp/2.22.9.78 A
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: GBWhatsApp/2.22.10.73 A
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: WhatsApp/2.22.9.76 i
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: WhatsApp/2.2349.2 W
+  os:
+    name: Windows
+    version: ""
+    platform: ""
+    family: Windows
+-
+  user_agent: WhatsApp/2.2214.12 N
+  os:
+    name: Mac
+    version: ""
+    platform: ""
+    family: Mac
+-
+  user_agent: Dalvik/2.1.0 (Linux; U; Android 11; Smart TV Build/RP1A.200622.001)
+  os:
+    name: Android TV
+    version: "11"
+    platform: ""
+    family: Android
+-
+  user_agent: Dalvik/2.1.0 (Linux; U; Android 9; SmartTV Build/RTK2842P)
+  os:
+    name: Android TV
+    version: "9"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; SMART_TV Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Safari/537.36
+  os:
+    name: Android TV
+    version: "9"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Armadillo Phone) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36
+  os:
+    name: Armadillo OS
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Helix Phone) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
+  os:
+    name: HELIX OS
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: FeedDaemon FRITZ!OS/07.12 Linux/2.6.39.3
+  os:
+    name: FRITZ!OS
+    version: "7.12"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; AEOAT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.6.3 like Chrome/112.0.5615.213 Safari/537.36
+  os:
+    name: Fire OS
+    version: "7"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.1) Gecko/20060324 Ubuntu/dapper Firefox/52.5.0
+  os:
+    name: Ubuntu
+    version: "6.06"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; nl; rv:1.8.0.4) Gecko/20060608 Ubuntu/dapper-security Firefox/52.4.1
+  os:
+    name: Ubuntu
+    version: "6.06"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Zeasn/2.0 Mozilla/5.0 (Linux;CE-HTML/1.0;U;en), Chrome/49.0.2623.87 Safari/537.36 AppleWebKit 537.36 (KHTML, like Gecko) Tbrowser/2.0, _TV_UNKONWN/V8-NT563LA-LF1V250 (WESTPOINT,TETS-4919SM,wireless)
+  os:
+    name: Whale OS
+    version: "1"
+    platform: ""
+    family: Other Smart TV
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 15_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 momoWebView/9.6.7 ios/5168(iPhone13,2;iOS 15.6.1;zh_CN;S1;netType/0)
+  os:
+    name: iOS
+    version: 15.6.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1.3) Gecko/20061201 MEGAUPLOAD 1.0 (Ubuntu-feisty)
+  os:
+    name: Ubuntu
+    version: "7.04"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; pl-PL; rv:1.9.0.1) Gecko/2008071222 Ubuntu/hardy Firefox/3.0.1
+  os:
+    name: Ubuntu
+    version: "8.04"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.11) Gecko/20070326 Ubuntu/breezy-security Epiphany/1.8.2 Firefox/1.5.0.11
+  os:
+    name: Ubuntu
+    version: "5.10"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; en-GB; rv:1.8.1b1) Gecko/20060601 BonEcho/2.0b1 (Ubuntu-edgy)
+  os:
+    name: Ubuntu
+    version: "6.10"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Liri/0.4.0
+  os:
+    name: Liri OS
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:2.0) Gecko/20110318 WebianShell/0.1
+  os:
+    name: Webian
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; System75) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15 Ubuntu/22.04 Eolie/605.1.15
+  os:
+    name: Ubuntu
+    version: "22.04"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Mi Max Prime Build/QP1A.191005.007) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.186 Mobile Safari/537.36
+  os:
+    name: Lineage OS
+    version: "17.0"
+    platform: ""
+    family: Android
+  headers:
+    http-x-requested-with: org.lineageos.jelly
+-
+  user_agent: Mozilla/5.0 (Linux; Android 13; SM-G920F Build/TQ3A.230901.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/117.0.0.0 Mobile Safari/537.36
+  os:
+    name: Lineage OS
+    version: "20.0"
+    platform: ""
+    family: Android
+  headers:
+    http-x-requested-with: org.lineageos.jelly
+-
+  user_agent: Mozilla/5.0 (Linux; Android 12; Moto Z3 Play Build/SQ3A.220705.004) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/104.0.5112.97 Mobile Safari/537.36
+  os:
+    name: Lineage OS
+    version: "19.0"
+    platform: ""
+    family: Android
+  headers:
+    http-x-requested-with: org.lineageos.jelly
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; lineage_j5y17lte Build/RQ2A.210305.006) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.152 Mobile Safari/537.36
+  os:
+    name: Lineage OS
+    version: "18.0"
+    platform: ""
+    family: Android
+-
+  user_agent: 'Mozilla/5.0 (Linux; Android 10; SM-A105F Build/Lineage_17.1-arm64_by_Eureka_Team; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/87.0.4280.101 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/399.0.0.24.93;]'
+  os:
+    name: Lineage OS
+    version: "17.1"
+    platform: ARM
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; lineage_serranoltexx) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
+  os:
+    name: Lineage OS
+    version: "16.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nexus 4 Build/OPM7.181205.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/72.0.3626.121 Mobile Safari/537.36
+  os:
+    name: Lineage OS
+    version: "15.1"
+    platform: ""
+    family: Android
+  headers:
+    http-x-requested-with: org.lineageos.jelly
+-
+  user_agent: Mozilla/5.0 (Linux; Android 8.0.0; lineage_athene Build/OPR6.170623.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3 282.140 Safari/537.36
+  os:
+    name: Lineage OS
+    version: "15.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.2; lineage_FS504 Build/NJH47F; ru-ru) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36 Puffin/7.8.2.40664AP
+  os:
+    name: Lineage OS
+    version: "14.1"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Moto G 2014 Build/NJH47F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112.78 Mobile Safari/537.36
+  os:
+    name: Lineage OS
+    version: "14.1"
+    platform: ""
+    family: Android
+  headers:
+    http-x-requested-with: org.lineageos.jelly
+-
+  user_agent: Dalvik/2.1.0 (Linux; U; Android 7.1.1; lineage_A6020 Build/NMF26V)
+  os:
+    name: Lineage OS
+    version: "14.1"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/4.5 Chrome/83.0.4103.120 Safari/537.36
+  os:
+    name: Fire OS
+    version: "8"
+    platform: ""
+    family: Android
+  headers:
+    http-x-requested-with: org.mozilla.tv.firefox
+-
+  user_agent: Apple AppleTV6,2 tvOS/17.1.0 Lifetime-tvOS/5.14.0 CFNetwork/1485
+  os:
+    name: tvOS
+    version: 17.1.0
+    platform: ARM
+    family: iOS
+-
+  user_agent: ClientApp/5.0.60 (tvOS 17.3; AppleTV6,2; Apple TV) PureRN/0.69.6
+  os:
+    name: tvOS
+    version: "17.3"
+    platform: ARM
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Linux; x86_64) Ladybird/1.0
+  os:
+    name: SerenityOS
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (SerenityOS; x86_64) LibWeb+LibJS/1.0 Browser/1.0
+  os:
+    name: SerenityOS
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.2) Gecko/2008110715 ASPLinux/3.0.2-3.0.120asp Firefox/52.0
+  os:
+    name: ASPLinux
+    version: 3.0.2
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: aws-internal/3 aws-sdk-java/1.12.90 Linux/5.4.156-94.273.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/25.302-b08 java/1.8.0_302 vendor/Oracle_Corporation cfg/retry-mode/standard
+  os:
+    name: Amazon Linux
+    version: "2"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; ElectroBSD amd64; rv:102.0) Gecko/20100101 Firefox/102.0
+  os:
+    name: ElectroBSD
+    version: ""
+    platform: x64
+    family: Unix
+-
+  user_agent: Pinterest for Android Tablet/11.42.2 (trona; 9)
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+    family: Android
+-
+  user_agent: myTuneriOS/55 CFNetwork/1496.0.1 Darwin/23.5.0
+  os:
+    name: iOS
+    version: "17.5"
+    platform: ""
+    family: iOS
+-
+  user_agent: Safari/19618.2.4.11.2 CFNetwork/1496.0.1 Darwin/23.5.0
+  os:
+    name: Mac
+    version: "14.5"
+    platform: ""
+    family: Mac
+-
+  user_agent: Podcast Player/1.0 (phone;ios Version 16.3.1 (Build 20D67))
+  os:
+    name: iOS
+    version: 16.3.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Podclipper/40 (miguelDSP.Podclipper; build:129; macOS(Catalyst) 13.2.1) Alamofire/5.7.1
+  os:
+    name: Mac
+    version: 13.2.1
+    platform: ""
+    family: Mac
+-
+  user_agent: iPad (compatible; Tablet2.0) NRC Digitale Editie, nl.nrc.nrcapp 10.0.7 (197) / iPadOS 16.6
+  os:
+    name: iPadOS
+    version: "16.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mimir-macOS/1.6.1
+  os:
+    name: Mac
+    version: ""
+    platform: ""
+    family: Mac
+-
+  user_agent: Gaana-iOS
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: Podfriend 2.0 ios
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: Podverse/iOS Mobile App
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: Goodpods.iOS / 3.5.4
+  os:
+    name: iOS
+    version: ""
+    platform: ""
+    family: iOS
+-
+  user_agent: NPROneAndroid
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: spotify_android-tablet
+  os:
+    name: Android
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: MXPlayer/1.73.3/2001002183; Android/33
+  os:
+    name: Android
+    version: "13"
+    platform: ""
+    family: Android
+-
+  user_agent: conda/23.5.0 requests/2.29.0 CPython/3.10.11 Darwin/22.5.0 OSX/13.4
+  os:
+    name: Mac
+    version: "13.4"
+    platform: ""
+    family: Mac
+-
+  user_agent: python-requests/2.2.1 CPython/2.7.5 Darwin/13.1.0
+  os:
+    name: Mac
+    version: 10.9.2
+    platform: ""
+    family: Mac
+-
+  user_agent: Boto3/1.17.18 Python/3.8.5 Darwin/19.6.0 Botocore/1.20.18
+  os:
+    name: Mac
+    version: 10.15.6
+    platform: ""
+    family: Mac
+-
+  user_agent: python-requests/2.6.0 CPython/3.8.9 Windows/10
+  os:
+    name: Windows
+    version: "10"
+    platform: ""
+    family: Windows
+-
+  user_agent: python-requests/2.7.0 CPython/2.7.18 Windows/8.1
+  os:
+    name: Windows
+    version: "8.1"
+    platform: ""
+    family: Windows
+-
+  user_agent: python-requests/2.7.0 CPython/2.7.18 Windows/7
+  os:
+    name: Windows
+    version: "7"
+    platform: ""
+    family: Windows
+-
+  user_agent: python-requests/2.7.0 CPython/2.7.0 Windows/2003Server
+  os:
+    name: Windows
+    version: Server 2003
+    platform: ""
+    family: Windows
+-
+  user_agent: python-requests/2.7.0 CPython/2.7.9 Windows/2012Server
+  os:
+    name: Windows
+    version: Server 2012
+    platform: ""
+    family: Windows
+-
+  user_agent: python-requests/2.7.0 CPython/2.7.18 Windows/2012ServerR2
+  os:
+    name: Windows
+    version: Server 2012 R2
+    platform: ""
+    family: Windows
+-
+  user_agent: python-requests/2.7.0 CPython/2.7.18 Windows/2008ServerR2
+  os:
+    name: Windows
+    version: Server 2008 R2
+    platform: ""
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (X11; AOSC OS; Linux loongarch64; rv:120.0) Gecko/20100101 Firefox/120.0
+  os:
+    name: AOSC OS
+    version: ""
+    platform: LoongArch64
+    family: GNU/Linux
+-
+  user_agent: conda/22.9.0 requests/2.26.0 CPython/3.8.6 Linux/4.19.190-6.2.4.lns8.loongarch64 loongnix-server/8.4.0 glibc/2.28
+  os:
+    name: Loongnix
+    version: 8.4.0
+    platform: LoongArch64
+    family: GNU/Linux
+-
+  user_agent: conda/4.8.2 requests/2.22.0 CPython/3.7.6 Linux/4.18.0-147.5.1.6.h841.eulerosv2r9.x86_64 ubuntu/18.04.6 glibc/2.27
+  os:
+    name: EulerOS
+    version: "2.9"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: conda/4.6.14 requests/2.21.0 CPython/3.7.3 Linux/3.10.0-957.12.1.el7.x86_64 scientific/7.6 glibc/2.17
+  os:
+    name: Scientific Linux
+    version: "7.6"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: conda/4.8.2 requests/2.22.0 CPython/3.7.6 Linux/5.4.46-1-lts alpine/3.9.5 glibc/2.28
+  os:
+    name: Alpine Linux
+    version: 3.9.5
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: conda/4.11.0 requests/2.28.1 CPython/3.10.6 Linux/5.19.1-1175.native clear-linux-os/36820 glibc/2.36
+  os:
+    name: Clear Linux OS
+    version: "36820"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: conda/23.5.0 requests/2.31.0 CPython/3.9.16 Linux/5.14.0-162.23.1.el9_1.x86_64 rocky/9.1 glibc/2.34
+  os:
+    name: Rocky Linux
+    version: "9.1"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: conda/4.10.3 requests/2.26.0 CPython/3.9.7 Linux/3.10.0-1160.53.1.el7.x86_64 centos/7.9.2009 glibc/2.17
+  os:
+    name: CentOS
+    version: 7.9.2009
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: conda/4.3.27 requests/2.18.4 CPython/2.7.13 Linux/3.10.0-957.27.2.el7.x86_64 CentOS Linux/7.6.1810 glibc/2.17
+  os:
+    name: CentOS
+    version: 7.6.1810
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: conda/4.3.31 requests/2.18.4 CPython/2.7.14 Linux/4.4.0-109-generic debian/stretch/sid glibc/2.23
+  os:
+    name: Debian
+    version: "9.13"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: conda/4.5.11 requests/2.18.4 CPython/3.6.4 Linux/2.6.32-696.20.1.el6.x86_64 rhel/6.9 glibc/2.12
+  os:
+    name: Red Hat
+    version: "6.9"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: conda/4.3.24 requests/2.14.2 CPython/3.6.1 Linux/3.10.0-514.el7.x86_64 Red Hat Enterprise Linux Server/7.3 glibc/2.17
+  os:
+    name: Red Hat
+    version: "7.3"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: conda/4.4.10 requests/2.18.4 CPython/3.6.4 Linux/4.4.114-94.14-default sles/12.3 glibc/2.22
+  os:
+    name: SUSE
+    version: "12.3"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Pinterest for iOS/12.3 (iPad11,6; 17.2)
+  os:
+    name: iPadOS
+    version: "17.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: python-requests/1.2.3 CPython/2.7.2 Windows/post2008Server
+  os:
+    name: Windows
+    version: "8"
+    platform: ""
+    family: Windows
+-
+  user_agent: python-requests/2.6.0 CPython/2.6.6 Linux/2.6.32-042stab127.2
+  os:
+    name: OpenVZ
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: python-requests/2.4.3 CPython/3.4.2 Linux/4.4.6-1-pve
+  os:
+    name: Proxmox VE
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: python-requests/2.4.3 CPython/3.7.2 Linux/4.9.35-v7+
+  os:
+    name: Proxmox VE
+    version: "7"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: RSSOwl/2.2.1.201312301316 (X11; U; en)
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Anytime/1.3.3 b95 (phone;android sdk_gphone64_arm64-userdebug 13 TE1A.220922.012 9302419 dev-keys) https://github.com/amugofjava/anytime_podcast_player
+  os:
+    name: Android
+    version: "13"
+    platform: ARM
+    family: Android
+-
+  user_agent: 'Trade Me/163.0 (Android: samsung (SM-S9210)); API 14'
+  os:
+    name: Android
+    version: "14"
+    platform: ""
+    family: Android
+-
+  user_agent: iPlayTV/3.3.9 (Apple TV; iOS 16.1; Scale/1.00)
+  os:
+    name: tvOS
+    version: "16.1"
+    platform: ARM
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; ko-KP, en; rv:1.8.1.8) Gecko/20090718 《붉은별》/2.5 NaenaraBrowser/2.0.0.8
+  os:
+    name: Red Star
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1b4) Gecko/20130508 Fedora/1.9.1-2.5.rs3.0 NaenaraBrowser/3.5b4
+  os:
+    name: Red Star
+    version: "3.0"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: NetworkingExtension/8619.1.10.2 CFNetwork/1555.1 Darwin/24.0.0
+  os:
+    name: Mac
+    version: "15.0"
+    platform: ""
+    family: Mac
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; xx; Baidu Yi on Passion Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) FlyFlow/2.2 Version/4.0 Mobile Safari/533.1
+  os:
+    name: Baidu Yi
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: Nokia-Communicator-WWW-Browser/3.0 (Geos 3.0 Nokia-9110)
+  os:
+    name: GEOS
+    version: "3.0"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; xx) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/531.2+ gNewSense/parkes (2.30.6-1gnewsense1) Epiphany/2.30.6
+  os:
+    name: gNewSense
+    version: 2.30.6
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; GENIX 4.1 MG-200/NS32332; en-US; rv:4.7.1.1) Gecko/20080815 SeaMonkey/1.2.3
+  os:
+    name: GENIX
+    version: "4.1"
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (X11; Jolicloud Linux i686) AppleWebKit/537.6 (KHTML, like Gecko) Joli OS/1.2 Chromium/23.0.1240.0 Chrome/23.0.1240.0 Safari/537.6
+  os:
+    name: Joli OS
+    version: "1.2"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; xx; rv:1.9.1.11) Gecko/20100728 Turbolinux/3.5.11-1 Firefox/3.5.11
+  os:
+    name: Turbolinux
+    version: 3.5.11
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Links (2.8; ULTRIX 4.5 VAX; GNU C 1; text)
+  os:
+    name: ULTRIX
+    version: "4.5"
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/1.1I (X11; I; NEWS-OS 6.1.1 news5000)
+  os:
+    name: NEWS-OS
+    version: 6.1.1
+    platform: ""
+    family: Unix
+-
+  user_agent: PhilipsX2300/W1245_V12 ThreadX_OS/4.0 MOCOR/W12 Release/11.08.2012 Browser/Dorado1.0
+  os:
+    name: ThreadX
+    version: "4.0"
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: WorldWideweb (NEXT)
+  os:
+    name: NeXTSTEP
+    version: ""
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (i386; AROS 0.0; Odyssey Web Browser; rv:1.23) AppleWebKit/538.1 (KHTML, like Gecko) OWB/1.23 Safari/538.1
+  os:
+    name: AROS
+    version: ""
+    platform: x86
+    family: AmigaOS
+-
+  user_agent: 'VMS_Mosaic/3.8-1 (Motif;OpenVMS V7.3-2 DEC 3000 - M700) libwww/2.12_Mosaic'
+  os:
+    name: OpenVMS
+    version: "7.3"
+    platform: ""
+    family: OpenVMS
+-
+  user_agent: Mozilla/4.08 (PDA; SL-C860/1.40,Qtopia/1.5.4) NetFront/3.1 480x640
+  os:
+    name: Qtopia
+    version: 1.5.4
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/6.0 (Future Star Technologies Corp. Star-Blade OS; U; en-US) iNet Browser 2.5
+  os:
+    name: Star-Blade OS
+    version: ""
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12; en-US; KIN.One 1.0)
+  os:
+    name: KIN OS
+    version: "1.0"
+    platform: ""
+    family: Windows Mobile
+-
+  user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12; en-US; KIN.Two 1.0)
+  os:
+    name: KIN OS
+    version: "1.0"
+    platform: ""
+    family: Windows Mobile
+-
+  user_agent: TCL_J720/1.0 WoPhone/1.0 UPhone/1.0 Browser/UPhoneWebBrowser1.0 Profile/MIDP-1.0 Configuration/CLDC-1.0
+  os:
+    name: WoPhone
+    version: "1.0"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: com.theepochtimes.mobile/2.41.3 b12 (iphoneos17.2; iPad14,8; en-US; America/Los_Angeles); Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
+  os:
+    name: iPadOS
+    version: "17.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: com.theepochtimes.mobile/2.37.1 b1 (iphoneos17.2; iPhone13,1; en-US; America/Phoenix); Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
+  os:
+    name: iOS
+    version: "17.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; blackPanther OS; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0
+  os:
+    name: blackPanther OS
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: VIZIO V655M-K04 ViziOS/1.4.512.847.1 WatchFree/24.06.13.2 FancyPlayer/1.1.30-qa
+  os:
+    name: ViziOS
+    version: 1.4.512.847.1
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: python-requests/2.7.0 CPython/3.6.12 Linux/4.4.0-1083-aws
+  os:
+    name: Amazon Linux
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: python-requests/2.2.1 CPython/2.7.6 Linux/4.9.80-c9
+  os:
+    name: Amazon Linux
+    version: "2023"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: python-requests/2.2.1 CPython/3.4.3 Linux/4.4.0-43-Microsoft
+  os:
+    name: Azure Linux
+    version: ""
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux; StarOS 9) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/4.7.2 Chrome/91.0.4472.77 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 14; RisingOS with Core GApps) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.26 YaBrowser/24.6.6.26.00 SA/3 Mobile Safari/537.36
+  os:
+    name: risingOS
+    version: ""
+    platform: ARM
+    family: Android
+-
+  user_agent: MobileSafari/8619.1.22.4 CFNetwork/1566.100.1 Darwin/24.1.0
+  os:
+    name: iOS
+    version: "18.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: Safari/20619.1.22.11.3 CFNetwork/1566.100.1 Darwin/24.1.0
+  os:
+    name: Mac
+    version: "15.1"
+    platform: ""
+    family: Mac
+-
+  user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15 (Ecosia ios@10.0.4.1853)
+  os:
+    name: Mac
+    version: 10.15.7
+    platform: ""
+    family: Mac
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 15_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) (Ecosia ios@4.0.6.795)
+  os:
+    name: iOS
+    version: 15.4.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Cloud Phone; Generic) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.243 Mobile Safari/537.36 Puffin/12.1.1.51391FP
+  os:
+    name: Puffin OS
+    version: ""
+    platform: ""
+    family: Android
+-
+  user_agent: AlMosafer/iPhone/17.0.3/8.10.0/1094/BDD0D3CE-EA37-4825-9E01-D26E91F38570/iPhone
+  os:
+    name: iOS
+    version: 17.0.3
+    platform: ""
+    family: iOS
+-
+  user_agent: Dalvik/2.1.0 (Linux; U; Android 9; Lenovo ThinkPad 11e 3rd Gen Chromebook Build/R103-14816.131.0)
+  os:
+    name: Chrome OS
+    version: 14816.131.0
+    platform: ""
+    family: Chrome OS
+-
+  user_agent: Dalvik/2.1.0 (Linux; U; Android 11; octopus Build/R119-15633.72.0)
+  os:
+    name: Chrome OS
+    version: 15633.72.0
+    platform: ""
+    family: Chrome OS
+-
+  user_agent: Mozilla/5.0 (Linux; Android 14; LeafOS on ARM64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36
+  os:
+    name: LeafOS
+    version: ""
+    platform: ARM
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; jacuzzi) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/21.0 Chrome/110.0.5481.154 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; kukui) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.104 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+-
+  user_agent: 'Fiddler/5.0.20244.10953 (.NET 4.8; WinNT 10.0.19045.0; en-US; 8xAMD64; Auto Update; Full Instance; Extensions: APITesting, AutoSaveExt, EventLog, FiddlerOrchestraAddon, HostsFile, RulesTab2, SAZClipboardFactory, SimpleFilter, Timeline)'
+  os:
+    name: Windows
+    version: "10"
+    platform: x64
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36
+  os:
+    name: LeafOS
+    version: ""
+    platform: ARM
+    family: Android
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 14.0.0
+    Sec-CH-UA-Model: LeafOS on ARM64
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36 OPR/86.0.4363.50
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 11.0.0
+    Sec-CH-UA-Model: octopus
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.134 Safari/537.36 OPR/88.0.4412.53
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 9.0.0
+    Sec-CH-UA-Model: trogdor
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.97 Safari/537.36 OPR/90.0.4480.54
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 9.0.0
+    Sec-CH-UA-Model: kukui
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.97 Safari/537.36 OPR/90.0.4480.54
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 9.0.0
+    Sec-CH-UA-Model: rammus
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.5249.126 Safari/537.36 OPR/92.0.4561.11
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 11.0.0
+    Sec-CH-UA-Model: hatch
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.196 Safari/537.36 OPR/100.0.4815.13
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 11.0.0
+    Sec-CH-UA-Model: nami
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5790.167 Safari/537.36 OPR/101.0.4843.33
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 11.0.0
+    Sec-CH-UA-Model: brya
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.5938.154 Safari/537.36 OPR/103.0.4928.26
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 11.0.0
+    Sec-CH-UA-Model: dedede
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.5938.154 Safari/537.36 OPR/103.0.4928.26
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 11.0.0
+    Sec-CH-UA-Model: nissa
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.280 Safari/537.36 OPR/106.0.4998.28
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: volteer
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.149 Safari/537.36 OPR/108.0.5067.24
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 11.0.0
+    Sec-CH-UA-Model: strongbad
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.88 Safari/537.36 OPR/85.0.4341.13
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 9.0.0
+    Sec-CH-UA-Model: coral
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.88 Safari/537.36 OPR/85.0.4341.13
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 9.0.0
+    Sec-CH-UA-Model: jacuzzi
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: octopus
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: brya
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 9.0.0
+    Sec-CH-UA-Model: coral
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: corsola
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: dedede
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 11.0.0
+    Sec-CH-UA-Model: grunt
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: hatch
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: jacuzzi
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 11.0.0
+    Sec-CH-UA-Model: nami
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: rammus
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: strongbad
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: volteer
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: zork
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; kukui) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.104 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: ""
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 9.0.0
+    Sec-CH-UA-Model: kukui
+-
+  user_agent: Mozilla/5.0 (Linux; Android 6.0; Rex) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 6.0.0
+    platform: ""
+    family: Android
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 6.0.0
+    Sec-CH-UA-Model: Rex
+-
+  user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36 Edg/117.0.2045.47
+  os:
+    name: Windows
+    version: ""
+    platform: x64
+    family: Windows
+  headers:
+    Sec-CH-UA-Platform: Windows
+    Sec-CH-UA-Platform-Version: 0.0.0
+    Sec-CH-UA-Arch: x86
+    Sec-CH-UA-Bitness: "64"
+-
+  user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.104 Safari/537.36
+  os:
+    name: Windows
+    version: "7"
+    platform: x64
+    family: Windows
+  headers:
+    Sec-CH-UA-Platform: Windows
+    Sec-CH-UA-Platform-Version: 0.1.0
+    Sec-CH-UA-Arch: x86
+    Sec-CH-UA-Bitness: "64"
+-
+  user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36
+  os:
+    name: Windows
+    version: "8"
+    platform: x64
+    family: Windows
+  headers:
+    Sec-CH-UA-Platform: Windows
+    Sec-CH-UA-Platform-Version: 0.2.0
+    Sec-CH-UA-Arch: x86
+    Sec-CH-UA-Bitness: "64"
+-
+  user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36
+  os:
+    name: Windows
+    version: "8.1"
+    platform: x86
+    family: Windows
+  headers:
+    Sec-CH-UA-Platform: Windows
+    Sec-CH-UA-Platform-Version: 0.3.0
+    Sec-CH-UA-Arch: x86
+    Sec-CH-UA-Bitness: "32"
+-
+  user_agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36 Edg/99.0.1150.39
+  os:
+    name: Windows
+    version: "8.1"
+    platform: x64
+    family: Windows
+  headers:
+    Sec-CH-UA-Platform: Windows
+    Sec-CH-UA-Platform-Version: 0.0.0
+    Sec-CH-UA-Arch: x86
+    Sec-CH-UA-Bitness: "64"
+-
+  user_agent: Safari/20620.1.11 CFNetwork/1568.300.61 Darwin/24.2.0
+  os:
+    name: Mac
+    version: "15.2"
+    platform: ""
+    family: Mac
+-
+  user_agent: Podcasts/4024.310.31.1 CFNetwork/1568.300.61 Darwin/24.2.0
+  os:
+    name: iOS
+    version: "18.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.3.1 like Chrome/122.0.6261.160 Safari/537.36
+  os:
+    name: Fire OS
+    version: "8"
+    platform: ""
+    family: Android
+  headers:
+    Sec-CH-UA-Platform: Android
+-
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 WebAppManager
+  os:
+    name: webOS
+    version: "22"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.128 Safari/537.36 WebAppManager
+  os:
+    name: webOS
+    version: "23"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.211 Safari/537.36 WebAppManager
+  os:
+    name: webOS
+    version: "24"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: azsdk-python-storage-blob/12.23.1 Python/3.12.6 (Windows-11-10.0.22631-SP0)
+  os:
+    name: Windows
+    version: "11"
+    platform: ""
+    family: Windows
+-
+  user_agent: AZURECLI/2.65.0 (MSI) azsdk-python-storage-blob/12.16.0 Python/3.11.8 (Windows-10-10.0.20348-SP0) VSTS_bbc9b9e6-59b6-4cd2-a1a6-91f2e5eb8d58_build_58_0
+  os:
+    name: Windows
+    version: "10"
+    platform: ""
+    family: Windows
+-
+  user_agent: azsdk-python-storage-blob/12.23.1 Python/3.13.0 (Windows-2025Server-10.0.26100-SP0)
+  os:
+    name: Windows
+    version: Server 2025
+    platform: ""
+    family: Windows
+-
+  user_agent: azsdk-python-storage-blob/12.23.0 Python/3.12.5 (Windows-2022Server-10.0.20348-SP0)
+  os:
+    name: Windows
+    version: Server 2022
+    platform: ""
+    family: Windows
+-
+  user_agent: azsdk-python-storage-blob/12.23.1 Python/3.13.0 (Windows-2019Server-10.0.17763-SP0)
+  os:
+    name: Windows
+    version: Server 2019
+    platform: ""
+    family: Windows
+-
+  user_agent: azsdk-python-storage-blob/12.23.0 Python/3.12.5 (Windows-2016Server-10.0.14393-SP0)
+  os:
+    name: Windows
+    version: Server 2016
+    platform: ""
+    family: Windows
+-
+  user_agent: azsdk-python-storage-blob/12.17.0 Python/3.12.4 (macOS-14.7-arm64-arm-64bit)
+  os:
+    name: Mac
+    version: "14.7"
+    platform: ARM
+    family: Mac
+-
+  user_agent: azsdk-python-storage-blob/12.23.1 Python/3.9.20 (Linux-6.5.0-1025-azure-x86_64-with-glibc2.31)
+  os:
+    name: Azure Linux
+    version: ""
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: azsdk-python-storage-blob/12.17.0 Python/3.11.10 (Linux-5.15.164.1-1.cm2-x86_64-with-glibc2.31)
+  os:
+    name: Azure Linux
+    version: "2"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: NEXT 64_VLC/3.0.14 LibVLC/3.0.14
+  os:
+    name: 'RTOS & Next'
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: 14/tclwebkit1.0.2
+  os:
+    name: Android
+    version: 4.0.1
+    platform: ""
+    family: Android
+-
+  user_agent: 15/tclwebkit1.0.2
+  os:
+    name: Android
+    version: 4.0.3
+    platform: ""
+    family: Android
+-
+  user_agent: 16/tclwebkit1.0.2
+  os:
+    name: Android
+    version: "4.1"
+    platform: ""
+    family: Android
+-
+  user_agent: 18/tclwebkit1.0.2
+  os:
+    name: Android
+    version: "4.3"
+    platform: ""
+    family: Android
+-
+  user_agent: 19/tclwebkit1.0.2
+  os:
+    name: Android
+    version: "4.4"
+    platform: ""
+    family: Android
+-
+  user_agent: 20/tclwebkit1.0.2
+  os:
+    name: Android
+    version: "4.4"
+    platform: ""
+    family: Android
+-
+  user_agent: 21/tclwebkit1.0.2
+  os:
+    name: Android
+    version: "5"
+    platform: ""
+    family: Android
+-
+  user_agent: ArcMobile2/56955.2 CFNetwork/3826.400.101 Darwin/24.3.0
+  os:
+    name: iOS
+    version: "18.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android-4.0.3; en-us; Galaxy Nexus Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7
+  os:
+    name: Android
+    version: 4.0.3
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 33; samsung SM-S911B) AppleWebKit/537.36 KHTML, like Gecko) Chrome/131.0.6778.135 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "13"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 34; OPPO CPH2625) AppleWebKit/537.36 KHTML, like Gecko) Chrome/129.0.6668.100 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "14"
+    platform: ""
+    family: Android
+-
+  user_agent: ArcMobile2/52159.2 CFNetwork/1498.700.2 Darwin/23.6.0
+  os:
+    name: iOS
+    version: "17.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: Safari/19618.3.11.11.5 CFNetwork/1498.700.2 Darwin/23.6.0
+  os:
+    name: Mac
+    version: "14.6"
+    platform: ""
+    family: Mac
+-
+  user_agent: NetworkingExtension/8618.3.11.10.5 CFNetwork/1498.700.2 Darwin/23.6.0
+  os:
+    name: Mac
+    version: "14.6"
+    platform: ""
+    family: Mac
+-
+  user_agent: NetworkingExtension/8619.2.8.10.9 CFNetwork/1568.200.51 Darwin/24.1.0
+  os:
+    name: Mac
+    version: "15.1"
+    platform: ""
+    family: Mac
+-
+  user_agent: NetworkingExtension/8619.1.26.30.5 Network/4277.2.5 iOS/18.0
+  os:
+    name: iOS
+    version: "18.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: NetworkingExtension/8619.1.26.30.7 Network/4277.2.6 iOS/18.0.1
+  os:
+    name: iOS
+    version: 18.0.1
+    platform: ""
+    family: iOS
+-
+  user_agent: NetworkingExtension/8619.2.8.10.7 Network/4277.42.2 iOS/18.1
+  os:
+    name: iOS
+    version: "18.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: NetworkingExtension/8619.2.8.10.9 Network/4277.42.2 iOS/18.1.1
+  os:
+    name: iOS
+    version: 18.1.1
+    platform: ""
+    family: iOS
+-
+  user_agent: NetworkingExtension/8620.2.4.10.7 Network/4277.82.1 iOS/18.3
+  os:
+    name: iOS
+    version: "18.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: NetworkingExtension/8620.1.16.10.11 Network/4277.60.255 iOS/18.2.1
+  os:
+    name: iOS
+    version: 18.2.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.99.234.5 Safari/537.36 Coolita OS QJY/2.0
+  os:
+    name: Coolita OS
+    version: "2.0"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.99.234.5 Safari/537.36 Coolita OS QJY/2.0 (; STV; AMLT921D; LiteOS3.0.0; E3A; )FXM-END
+  os:
+    name: Coolita OS
+    version: 3.0.0
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36 CrKey/1.0.999999 VIZIO SmartCast(Conjure/NVTA-7.603.31.0-prod FW/7.2-2 Model/VFD40M-0809)
+  os:
+    name: ViziOS
+    version: ""
+    platform: ARM
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36 OPR/36.0.2128.0 OMI/4.8.0.129.ALISHAN6.19 VIZIO-DTV/V7.20.8 (Vizio, D32f-E1, wireless)
+  os:
+    name: ViziOS
+    version: ""
+    platform: ARM
+    family: GNU/Linux
+-
+  user_agent: MobileSafari/8621.1.10.20.6 CFNetwork/3826.500.62.2.1 Darwin/24.4.0
+  os:
+    name: iOS
+    version: "18.4"
+    platform: ""
+    family: iOS
+-
+  user_agent: Safari/20621.1.10.21.6 CFNetwork/3826.500.61.1.1 Darwin/24.4.0
+  os:
+    name: Mac
+    version: "15.4"
+    platform: ""
+    family: Mac
+-
+  user_agent: Microsoft-Windows-XP/2002, UPnP/1.1, J. River Internet Reader/2.0 (compatible; Windows-Media-Player/10)
+  os:
+    name: Windows
+    version: XP
+    platform: ""
+    family: Windows
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 1.5.2.0-RT-20120926.155001; xx; K-Touch W619 Build/AliyunOs-2012) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 SogouMSE,SogouMobileBrowser/2.1.0
+  os:
+    name: YunOS
+    version: 1.5.2.0
+    platform: ""
+    family: Android
+-
+  user_agent: MobileSafari/8621.2.1.10.3 CFNetwork/3826.500.121 Darwin/24.5.0
+  os:
+    name: iOS
+    version: "18.5"
+    platform: ""
+    family: iOS
+-
+  user_agent: NetworkingExtension/8622.1.10.1 CFNetwork/3848.100.2 Darwin/25.0.0
+  os:
+    name: Mac
+    version: "26.0"
+    platform: ""
+    family: Mac
+-
+  user_agent: KolibriOS libHTTP/1.1
+  os:
+    name: KolibriOS
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: Mozilla/5.0 (Phone; OpenHarmony 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 ArkWeb/4.1.6.1 Mobile MicroMessenger/8.0.9.39(0xf3100927) Weixin NetType/WIFI Language/zh_CN MMWEBID/2777 MMWEBSDK/202507060011 XWEB/1140307
+  os:
+    name: OpenHarmony
+    version: "5.1"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36
+  os:
+    name: Chrome OS
+    version: ""
+    platform: x64
+    family: Chrome OS
+  headers:
+    Sec-CH-UA-Platform: Android
+    Sec-CH-UA-Platform-Version: 13.0.0
+    Sec-CH-UA-Model: rauru
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; zh-cn; OC106 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.9 Mobile Safari/537.36
+  os:
+    name: Smartisan OS
+    version: "6.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; OE106 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
+  os:
+    name: Smartisan OS
+    version: "6.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; DT1901A Build/PKQ1.190727.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/12.8.9.1069 Mobile Safari/537.36
+  os:
+    name: Smartisan OS
+    version: "6.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DE106 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile
+  os:
+    name: Smartisan OS
+    version: "6.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; DT2002C Build/QKQ1.200712.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
+  os:
+    name: Smartisan OS
+    version: "6.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 10; Smartisan U3 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.216 YaApp_Android/21.53.1 YaSearchBrowser/21.53.1 BroPP/1.0 SA/3 Mobile Safari/537.36
+  os:
+    name: Smartisan OS
+    version: "3.0"
+    platform: ARM
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM919 Build/MXB48T; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043024 Safari/537.36 MicroMessenger/6.5.4.1000 NetType/WIFI Language/zh_CN
+  os:
+    name: Smartisan OS
+    version: "3.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM801 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043024 Safari/537.36 MicroMessenger/6.5.4.1000 NetType/4G Language/zh_CN
+  os:
+    name: Smartisan OS
+    version: "2.5"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; zh-CN; YQ601 Build/LMY47V) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.9.3.727 U3/0.8.0 Mobile Safari/534.30
+  os:
+    name: Smartisan OS
+    version: "2.0"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; SM701 Build/SANFRANCISCO) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025469 Mobile Safari/533.1 MicroMessenger/6.2.5.49_r7ead8bf.620 NetType/WIFI Language/zh_CN QQ/6.6.0.2935
+  os:
+    name: Smartisan OS
+    version: "1.5"
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.270 Safari/537.36 WebAppManager
+  os:
+    name: webOS
+    version: "25"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 26_0_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/376.0.777690323 Mobile/15E148 Safari/604.1
+  os:
+    name: iOS
+    version: 26.0.0
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 19_0 like Mac OS X) WebKit/8612 (KHTML, like Gecko) Mobile/23A344 [FBAN/FBIOS;FBDV/iPhone18,4;FBMD/iPhone;FBSN/iOS;FBSV/19.0;FBSS/3;FBID/phone;FBLC/ru_RU;FBOP/5]
+  os:
+    name: iOS
+    version: "26.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: com.linkedin.android/179800 (Linux; U; Android 14; de_DE; Pixel 6; Build/UP1A.231105.003; Cronet/102.0.5005.125)
+  os:
+    name: Android
+    version: "14"
+    platform: ""
+    family: Android
+-
+  user_agent: Superbalist/3.50.0-huawei(com.superbalist.huawei;329;Android;12;API31)
+  os:
+    name: Android
+    version: "12"
+    platform: ""
+    family: Android
+-
+  user_agent: Instagram 361.0.0.46.88 Android (33/13; 440dpi; 1080x2263; Xiaomi/Redmi; M2101K6G; sweet; qcom; tr_TR; 674675063)
+  os:
+    name: Android
+    version: "13"
+    platform: ""
+    family: Android
+-
+  user_agent: Torbrowser/6.2.1 CFNetwork/3826.600.41 Darwin/24.6.0
+  os:
+    name: iOS
+    version: "18.6"
+    platform: ""
+    family: iOS
+-
+  user_agent: OperaGX/3853 CFNetwork/3860.200.71 Darwin/25.1.0
+  os:
+    name: iOS
+    version: "26.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: Opera/4 CFNetwork/3860.300.31 Darwin/25.2.0
+  os:
+    name: iOS
+    version: "26.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: com.apple.WebKit.Networking/20621.3.11.11.3 CFNetwork/3826.600.41 Darwin/24.6.0
+  os:
+    name: Mac
+    version: "15.6"
+    platform: ""
+    family: Mac
+-
+  user_agent: com.apple.WebKit.Networking/21622.2.11.11.9 CFNetwork/3860.200.71 Darwin/25.1.0
+  os:
+    name: Mac
+    version: "26.1"
+    platform: ""
+    family: Mac
+-
+  user_agent: NetworkingExtension/8623.1.13.10.3 CFNetwork/3860.300.31 Darwin/25.2.0
+  os:
+    name: Mac
+    version: "26.2"
+    platform: ""
+    family: Mac
+-
+  user_agent: 'Hulu/1.172.2 (Fire OS 7.7.0.6 (PS7706/5106); ; AFTSSS; Build/Neutron - 1.4.559)'
+  os:
+    name: Fire OS
+    version: 7.7.0.6
+    platform: ""
+    family: Android
+-
+  user_agent: Mozilla/4.0 (compatible; MSIE 6.0; j2me) ReqwirelessWeb/3.5
+  os:
+    name: Java ME
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: GIONEE S80/Q03C MAUI-browser/MIDP2.0/CLDC1.1/Screen-240X320
+  os:
+    name: Java ME
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: ArcMobile2/70582.2 CFNetwork/3860.400.1 Darwin/25.3.0
+  os:
+    name: iOS
+    version: "26.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: NetworkingExtension/8623.2.2 CFNetwork/3860.400.1 Darwin/25.3.0
+  os:
+    name: Mac
+    version: "26.3"
+    platform: ""
+    family: Mac
+-
+  user_agent: TeraBox/4.9.3.1 CFNetwork/3860.100.1 Darwin/25.0.0
+  os:
+    name: iOS
+    version: "26.0"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.128 Safari/537.36 OMI/4.24.3.93.MIKE.227 Model/Vestel-MB190 VSTVB MB100 FVC/9.0 (VESTEL; MB190; ) HbbTV/1.7.1 (+DRM; VESTEL; MB190; 0.9.0.0; ; _TV__2025;) TitanOS/3.0 (Vestel MB190 VESTEL) SmartTvA/3.0.0
+  os:
+    name: Titan OS
+    version: "3.0"
+    platform: ""
+    family: Other Smart TV
+-
+  user_agent: Mozilla/5.0 (SmartHub; SMART-TV; U; Linux/SmartTV; Maple2012) AppleWebKit/534.7 (KHTML, like Gecko) SmartTV Safari/534.7
+  os:
+    name: Orsay
+    version: ""
+    platform: ""
+    family: Other Smart TV
+-
+  user_agent: HbbTV/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit
+  os:
+    name: Orsay
+    version: ""
+    platform: ""
+    family: Other Smart TV
+-
+  user_agent: ChatGPT/1.2025.308 (iOS 17.7.10; iPad7,5; build 19181868194)
+  os:
+    name: iPadOS
+    version: 17.7.10
+    platform: ""
+    family: iOS
+-
+  user_agent: Tor Browser/5.7 (Redhat Linux 2.0; ar_YE;)
+  os:
+    name: Red Hat
+    version: "2.0"
+    platform: ""
+    family: GNU/Linux
+-
+  user_agent: 'Mozilla/4.79C-SGI [en] (X11; I; IRIX64 6.5 IP28)'
+  os:
+    name: IRIX
+    version: "6.5"
+    platform: x64
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64; openSUSE 13.2 (Harlequin) (x86_64)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.0 Maxthon/1.0.5.3 Safari/537.36
+  os:
+    name: openSUSE
+    version: "13.2"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; U; OpenVMS AlphaServer_ES40; en-US; rv:1.4) Gecko/20030826 SWB/V1.4 (HP)
+  os:
+    name: OpenVMS
+    version: ""
+    platform: ""
+    family: OpenVMS
+-
+  user_agent: Mozilla/5.0 (X11; U; IRIX IP22; en-US; rv:1.0.2) Gecko/20030820
+  os:
+    name: IRIX
+    version: ""
+    platform: ""
+    family: Unix
+-
+  user_agent: ELinks/0.11.4-2 (textmode; Debian; GNU/kFreeBSD 6.3-1-486 i686; 141x21-2)
+  os:
+    name: Debian
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; BSD Four) AppleWebKit/534.34 (KHTML, like Gecko) Qt/4.8.5 Safari/534.34
+  os:
+    name: BSD
+    version: "4"
+    platform: ""
+    family: Unix
+-
+  user_agent: 'Mozilla/5.0 (Linux 2.4.20-gentoo-r5 i686; U) Opera 7.11  [en]'
+  os:
+    name: Gentoo
+    version: ""
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: OperaMini(MAUI_MRE;Opera Mini/4.4.33576;fr)
+  os:
+    name: MRE
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: Opera/9.80 (MAUI Runtime; Opera Mini/4.4.33576/191.293; U; fr) Presto/2.12.423 Version/12.16
+  os:
+    name: MRE
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: NativeOperaMini(MRE_VER_2202;240X320;MT6276;V/;Opera Mini/6.1.27412;fr)
+  os:
+    name: MRE
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: GIONEE50_12864_11B_HW (MRE\\2.5.00(3072) resolution\\240320 chipset\\MT6250 touch\\1 tpannel\\0 camera\\1 gsensor\\0 keyboard\ormal) 1307SY_0201_V1045 Release/2013.06.28 WAP Browser/MAUI (HTTP PGDL; HTTPS) Profile/Profile/MIDP-2.0 Configuration/CLDC-1.1 Q03C1-2.40 en-US
+  os:
+    name: MRE
+    version: 2.5.00
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: Opera/9.80 (SpreadTrum; Opera Mini/4.4.31227/191.268; U; en) Presto/2.12.423 Version/12.16
+  os:
+    name: Mocor OS
+    version: ""
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/604.1 (KHTML, like Gecko) Version/11.0 Safari/604.1 elementary OS/0.4 (Loki) Epiphany/3.18.11
+  os:
+    name: elementary OS
+    version: "0.4"
+    platform: x64
+    family: GNU/Linux
+-
+  user_agent: Mozilla/5.0 (X11; GhostBSD/10.3; x86_64; rv:50.0.1) Gecko/20100101 Firefox/50.0.1
+  os:
+    name: GhostBSD
+    version: "10.3"
+    platform: x64
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (OS/2; ArcaOS 5.0.6; x86_64; rv:89.0) Gecko/20100101 Firefox/89.0
+  os:
+    name: ArcaOS
+    version: 5.0.6
+    platform: x64
+    family: IBM
+-
+  user_agent: Mozilla/5.0 (OS/2; ArcaOS; x64; rv:89.0) Gecko/20100101 Firefox/89.0
+  os:
+    name: ArcaOS
+    version: ""
+    platform: x64
+    family: IBM
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9b5pre) Gecko/2008032619 Linpus/3.0-0.49
+  os:
+    name: Linpus
+    version: "3.0"
+    platform: x86
+    family: GNU/Linux
+-
+  user_agent: NCSA_Mosaic/5.0 (X11;Plan 9 4.0)
+  os:
+    name: Plan 9
+    version: "4.0"
+    platform: ""
+    family: Unix
+-
+  user_agent: Mozilla/5.0 (X11; Original ; Minix 3.3 ; rv:3.0)
+  os:
+    name: MINIX
+    version: "3.3"
+    platform: ""
+    family: Unix
+-
+  user_agent: Contiki/1.0 (Commodore 64; http://dunkels.com/adam/contiki/)
+  os:
+    name: Contiki
+    version: "1.0"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Contiki/1.2-pre0 http://dunkels.com/adam/contiki/
+  os:
+    name: Contiki
+    version: "1.2"
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: Contiki/2.2.2 http://www.sics.se/contiki/
+  os:
+    name: Contiki
+    version: 2.2.2
+    platform: ""
+    family: Other Mobile
+-
+  user_agent: NuttX/6.xx.x (; http://www.nuttx.org/)
+  os:
+    name: NuttX
+    version: "6"
+    platform: ""
+    family: Real-time OS
+-
+  user_agent: com.apple.Safari.SearchHelper/8624.1.4.1 CFNetwork/3860.500.41 Darwin/25.4.0
+  os:
+    name: Mac
+    version: "26.4"
+    platform: ""
+    family: Mac
+-
+  user_agent: Opera/15 CFNetwork/3860.500.83 Darwin/25.4.0
+  os:
+    name: iOS
+    version: "26.4"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.7.2 Mobile/15E148 Safari/604.1
+  os:
+    name: iOS
+    version: 18.7.2
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0.1 Mobile/15E148 Safari/604.1
+  os:
+    name: iOS
+    version: 26.0.1
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.1 Mobile/15E148 Safari/604.1
+  os:
+    name: iOS
+    version: "26.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.2 Mobile/15E148 Safari/604.1
+  os:
+    name: iOS
+    version: "26.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3 Mobile/15E148 Safari/604.1
+  os:
+    name: iOS
+    version: "26.3"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Mobile/15E148 Safari/604.1
+  os:
+    name: iOS
+    version: "26.4"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148;super/4.21.4/iOS/26.1
+  os:
+    name: iOS
+    version: "26.1"
+    platform: ""
+    family: iOS
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148;super/4.22.1/iOS/26.2
+  os:
+    name: iOS
+    version: "26.2"
+    platform: ""
+    family: iOS
+-
+  user_agent: 'Mozilla/5.0 (iPad; CPU OS 19_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/19.0 Mobile/15E148 Safari/604.1'
+  os:
+    name: iPadOS
+    version: "19.0"
+    platform: ""
+    family: iOS

--- a/tests/data/fixtures/smartphone-12.yml
+++ b/tests/data/fixtures/smartphone-12.yml
@@ -844,8 +844,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM919 Build/MXB48T; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043024 Safari/537.36 MicroMessenger/6.5.4.1000 NetType/WIFI Language/zh_CN
   os:
-    name: Android
-    version: 6.0.1
+    name: Smartisan OS
+    version: "3.0"
     platform: ""
   client:
     type: mobile app
@@ -860,8 +860,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; zh-cn; OC106 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.9 Mobile Safari/537.36
   os:
-    name: Android
-    version: 7.1.2
+    name: Smartisan OS
+    version: "6.0"
     platform: ""
   client:
     type: browser
@@ -878,8 +878,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; zh-CN; OC105 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1077 Mobile Safari/537.36
   os:
-    name: Android
-    version: 7.1.2
+    name: Smartisan OS
+    version: "6.0"
     platform: ""
   client:
     type: browser
@@ -896,8 +896,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; OE106 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
-    name: Android
-    version: 8.1.0
+    name: Smartisan OS
+    version: "6.0"
     platform: ""
   client:
     type: browser
@@ -914,8 +914,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; DT1901A Build/PKQ1.190727.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/12.8.9.1069 Mobile Safari/537.36
   os:
-    name: Android
-    version: "9"
+    name: Smartisan OS
+    version: "6.0"
     platform: ""
   client:
     type: browser
@@ -968,8 +968,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DE106 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile
   os:
-    name: Android
-    version: 8.1.0
+    name: Smartisan OS
+    version: "6.0"
     platform: ""
   client:
     type: browser
@@ -986,8 +986,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; SM701 Build/SANFRANCISCO) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025469 Mobile Safari/533.1 MicroMessenger/6.2.5.49_r7ead8bf.620 NetType/WIFI Language/zh_CN QQ/6.6.0.2935
   os:
-    name: Android
-    version: 4.4.2
+    name: Smartisan OS
+    version: "1.5"
     platform: ""
   client:
     type: mobile app
@@ -1002,8 +1002,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM801 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043024 Safari/537.36 MicroMessenger/6.5.4.1000 NetType/4G Language/zh_CN
   os:
-    name: Android
-    version: 5.1.1
+    name: Smartisan OS
+    version: "2.5"
     platform: ""
   client:
     type: mobile app
@@ -1018,8 +1018,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; zh-CN; YQ601 Build/LMY47V) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.9.3.727 U3/0.8.0 Mobile Safari/534.30
   os:
-    name: Android
-    version: 5.1.1
+    name: Smartisan OS
+    version: "2.0"
     platform: ""
   client:
     type: browser

--- a/tests/data/fixtures/smartphone-22.yml
+++ b/tests/data/fixtures/smartphone-22.yml
@@ -7984,8 +7984,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; Android 10; DT1902A Build/QKQ1.191222.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.62
   os:
-    name: Android
-    version: "10"
+    name: Smartisan OS
+    version: "6.0"
     platform: ""
   client:
     type: browser

--- a/tests/data/fixtures/smartphone-27.yml
+++ b/tests/data/fixtures/smartphone-27.yml
@@ -812,8 +812,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; Android 10; DT2002C Build/QKQ1.200712.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
-    name: Android
-    version: "10"
+    name: Smartisan OS
+    version: "6.0"
     platform: ""
   client:
     type: browser

--- a/tests/data/fixtures/smartphone-28.yml
+++ b/tests/data/fixtures/smartphone-28.yml
@@ -4586,8 +4586,8 @@
 -
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 10; Smartisan U3 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.216 YaApp_Android/21.53.1 YaSearchBrowser/21.53.1 BroPP/1.0 SA/3 Mobile Safari/537.36
   os:
-    name: Android
-    version: "10"
+    name: Smartisan OS
+    version: "3.0"
     platform: ARM
   client:
     type: browser

--- a/tests/php_tests/parser/oss.rs
+++ b/tests/php_tests/parser/oss.rs
@@ -22,8 +22,19 @@ fn test_oss() -> Result<()> {
         };
         let mut cases: Value = serde_yaml::from_reader(std::io::BufReader::new(file))?;
         let cases = cases.as_sequence_mut().expect("sequence");
+        let mut failures = 0;
         for (i, case) in cases.into_iter().enumerate() {
-            basic(i + 1, case).expect("basic test");
+            let ua = case["user_agent"].as_str().unwrap_or("").to_owned();
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                basic(i + 1, case).expect("basic test");
+            }));
+            if result.is_err() {
+                failures += 1;
+                eprintln!("FAIL case {}: ua={}", i + 1, ua);
+            }
+        }
+        if failures > 0 {
+            panic!("{} test case(s) failed", failures);
         }
     }
     Ok(())


### PR DESCRIPTION
1. iOS 26 Version Remapping:
Apple internally versioned iOS 26 as iOS 19. UA strings from some apps (e.g. Facebook) still reports CPU iPhone OS 19_0. The Rust generic catch-all pattern would return 19.0 as-is instead of mapping it to the public version 26.0.

Solution:
Added a new pattern to regexes/oss.yml before the generic catch-all. Placement before the generic catch-all is critical; the generic pattern would otherwise consume the UA first and return the wrong version.
regex: (?:CPU OS|iPh(?:one)?[ _]OS|iPhone.+ OS|PodMN.+iPhone|iOS)[ _/]19(?:[_.])?(\d+(?:[._]\d+)*)
name: iOS
version: 26.$1

Tests in tests/data/fixtures/parser/oss.yml:
user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 19_0 like Mac OS X) WebKit/8612 ... [FBAN/FBIOS;...FBSV/19.0;...]
os:
    name: iOS
    version: 26.0
    family: iOS


2. Safari Version Freeze Detection:
On iOS 26, Safari entered a version freeze where the UA still reports iPhone OS 18_7 but the actual iOS version is embedded in the “Version/” token (e.g. Version/26.1) or as a trailing iOS/26.1 token. Without these patterns, Rust would extract 18.7 instead of the real version.

Solution:
Added two new patterns (in regexes/oss.yml) before the generic catch-all.
- regex: iPhone OS 18_7.+Version/(\d+[.\d]+)
   name: iOS
   version: $1
- regex: iOS/(\d+[.\d]+)$
   name: iOS
   version: $1

Tests in tests/data/fixtures/parser/oss.yml:
8 cases covering both patterns:
- Version/ freeze cases
user_agent: ...iPhone OS 18_7...Version/18.7.2...  → iOS 18.7.2
user_agent: ...iPhone OS 18_7...Version/26.0.1...  → iOS 26.0.1
user_agent: ...iPhone OS 18_7...Version/26.1...    → iOS 26.1
user_agent: ...iPhone OS 18_7...Version/26.2...    → iOS 26.2
user_agent: ...iPhone OS 18_7...Version/26.3...    → iOS 26.3
user_agent: ...iPhone OS 18_7...Version/26.4...    → iOS 26.4

- Trailing iOS/X.Y cases
user_agent: ...iPhone OS 18_7.../iOS/26.1   → iOS 26.1
user_agent: ...iPhone OS 18_7.../iOS/26.2  → iOS 26.2


3. Darwin iOS Version Table Gaps:
The iOS CFNetwork/Darwin versions (in regexes/oss.yml) only had Darwin 25.0.0 → 26 and stopped at 24.5.0 → 18.5. Newer Darwin kernel versions were unrecognised, causing those iOS versions to go undetected.

Solution:
Added explicit entries to the iOS versions.
regex: Darwin/25\.4\.0
   	version: 26.4
regex: Darwin/25\.3\.0
    	version: 26.3
regex: Darwin/25\.2\.0
    	version: 26.2
regex: Darwin/25\.1\.0
    	version: 26.1
regex: Darwin/25\.0\.0
    	version: 26
regex: Darwin/24\.6\.0
    	version: 18.6
regex: Darwin/24\.5\.0
    	version: 18.5

Tests in tests/data/fixtures/parser/oss.yml:
Covered by the test cases for com.apple.WebKit.Networking, which use Darwin 24.6.0 and 25.1.0 (see bullet point 7)


4. Darwin Mac Version Table Gaps:
Same gap as above but for macOS. The Mac versions stopped at Darwin 24.5.0 → 15.5, missing newer Darwin kernel to macOS version mappings.

Solution:
Added explicit entries to the Mac versions.
regex: (?:x86_64-apple-)?Darwin(?:/|; )?25\.4\.0
    	version: 26.4
regex: (?:x86_64-apple-)?Darwin(?:/|; )?25\.3\.0
    	version: 26.3
regex: (?:x86_64-apple-)?Darwin(?:/|; )?25\.2\.0
    	version: 26.2
regex: (?:x86_64-apple-)?Darwin(?:/|; )?25\.1\.0
    	version: 26.1
regex: (?:x86_64-apple-)?Darwin(?:/|; )?25\.0\.0
    	version: 26
regex: (?:x86_64-apple-)?Darwin(?:/|; )?24\.6\.0
    	version: 15.6
regex: (?:x86_64-apple-)?Darwin(?:/|; )?24\.5\.0
    	version: 15.5

Tests in tests/data/fixtures/parser/oss.yml:
Covered by the test cases for com.apple.WebKit.Networking (see bullet point 7)


5. iPadOS/iOS Version Range Ceiling:
iPadOS and iOS patterns used (1[3-8]|26) as their version range, capping at iOS/iPadOS 18. Any UA string reporting version 19.x would not match these patterns and fall through undetected or misclassified.

Rust-Device-Detection Library Solution:
Changed all 8 occurrences of 1[3-8] to 1[3-9] in regexes/oss.yml, covering.
- FBMD/iPad FBSV pattern (line 1329)
- iPad(?:OS)?[ /] pattern (line 1333)
- ^iPad\d+/ pattern (line 1337)
- iPad CPU OS pattern (line 1341)
- iOS[ /]...+iPad pattern (line 1345)
- iPhone OS,...+iPad pattern (line 1349)
- iphoneos...; iPad pattern (line 1353)
- iphoneos...; iPhone pattern (line 1372)

Tests in tests/data/fixtures/parser/oss.yml:
user_agent: Mozilla/5.0 (iPad; CPU OS 19_0 like Mac OS X) AppleWebKit/605.1.15 ... Version/19.0 Mobile/15E148 Safari/604.1
os:
    name: iPadOS
    version: 19.0
    family: iOS


6. iPadOS Structural Pattern Correction:
The original iPadOS iOS/...+iPad pattern (iOS/(1[3-8]|26)\.(\d+[.\d]).+Apple/iPad) in the rust-device-detection library was too narrow in two ways:
- Only accepted / as separator (not space)
- Required the exact string Apple/iPad rather than any iPad substring

Solution:
Updated pattern in regexes/oss.yml to match the Matomo PHP reference.
- Before
regex: iOS/(1[3-8]|26)\.(\d+[.\d]*).+Apple/iPad
- After
regex: iOS[ /](1[3-9]|26)\.(\d+[.\d]*).+iPad

No New Test Added:
The change was already covered by the existing broad fixture suite (92 tests), which continued to pass.


7. Routing for com.apple.WebKit.Networking: 
The com.apple.WebKit.Networking is a macOS networking process. Its UA strings (e.g. com.apple.WebKit.Networking/… CFNetwork/... Darwin/24.6.0) were being incorrectly classified as iOS because the iOS CFNetwork/Darwin regex didn't exclude them, and the Mac regex didn't include them.

Solution:
Two changes to regexes/oss.yml.
iOS negative lookahead (line 1408) — added exclusion:
  	# Before
  	^(?!com\.apple\.Safari\.SearchHelper|Safari|NetworkingExtension)
  	# After
        ^(?!com\.apple\.Safari\.SearchHelper|Safari|com\.apple\.WebKit\.Networking|NetworkingExtension)

Mac positive match (line 1659) — added inclusion:
 	# Before
  	^(?:NetworkingExtension|Safari)
 	 # After
  	^(?:com\.apple\.WebKit\.Networking|NetworkingExtension|Safari)


Tests in tests/data/fixtures/parser/oss.yml:
2 cases ported directly from the Matomo PHP library.
user_agent: com.apple.WebKit.Networking/20621.3.11.11.3 CFNetwork/3826.600.41 Darwin/24.6.0
    	os:
      	   name: Mac
      	   version: 15.6    # also validates Darwin 24.6 entry
   family: Mac

user_agent: com.apple.WebKit.Networking/21622.2.11.11.9 CFNetwork/3860.200.71 Darwin/25.1.0
   	os:
      	   name: Mac
      	   version: 26.1    # also validates Darwin 25.1 entry
   family: Mac


8. New OS Entries:
Added 17 operating systems that existed in PHP's registry but were missing from the Rust implementation. These include NuttX, Contiki, MINIX, Plan 9, Linpus, ArcaOS, GhostBSD, elementary OS, Mocor OS, Titan OS, KolibriOS, Coolita OS, Orsay, Smartisan OS, OpenHarmony, BSD (generic), and openSUSE. Without these entries, the parser had no family or desktop metadata for devices running these OSes.


9. New Detection Regexes:
Added regex patterns to oss.yml for several OSes that had no detection rules at all: NuttX, Contiki, MINIX, Plan 9, Linpus, ArcaOS, GhostBSD, elementary OS, Mocor OS, Titan OS, Orsay, OpenHarmony, Smartisan OS (with model-specific version mapping), MRE/MAUI Runtime, and BSD Four. Also added new Android detection patterns to handle non-standard UA formats used by apps like Superbalist and Instagram.


10. Regex Bug Fixes: 
Several existing detection patterns had subtle errors that were fixed.
Fire OS: The device regex inadvertently matched /kFreeBSD because the character class KF[ADFGJKMORSTQ] included R, which matched the r in kFr. Fixed by requiring a leading space.
IRIX: Added support for the IRIX;64 variant and made the version number optional.
OpenVMS: Fixed the version capture group.
SUSE/openSUSE: openSUSE was missing from the alternation and was being swallowed by the SUSE match without the name being preserved correctly.
Red Hat: Broadened the pattern to cover additional UA formats.
Gentoo: Added a catch-all pattern for UAs that embed gentoo without a version.
Java ME: Expanded the pattern to cover additional CLDC/MIDP UA formats used by feature phones.
Fire OS separator: Fixed the version separator regex to correctly capture versions in varied UA formats.
Android lookbehind: Added com.linkedin. to the negative lookbehind to prevent the LinkedIn app's package name (com.linkedin.android/179800) from being mis-detected as Android version 179800.
x64 platform detection: Fixed the regex to correctly handle IRIX;64 and x86_64 variants.
webOS: Added a Chrome 120-era version mapping.
Darwin version: Fixed version string for Darwin 25.0.0 (maps to OS version 26.0).


11. Client Hints: UA Restoration:
Matomo PHP device-detector reconstructs the user agent string from client hints before running OS regex matching, a step that was entirely missing from the rust device detector implementation. This is critical for two scenarios:
Android "K" placeholder: Modern Android Chrome uses Android 10; K as a privacy-preserving generic UA. PHP replaces this with the real Android version and device model from client hints (e.g., Android 14.0.0; octopus), which then allows Chrome OS codename patterns to match correctly.
Desktop Linux: When a desktop UA contains X11; Linux x86_64, PHP appends the client hints model name, enabling more specific detection (e.g., Chrome OS codenames on Chromebooks).


12. Client Hints: Merge Logic Fixes:
Several bug fixes in how client hints data and UA-derived data were merged.
Windows version mapping: Added support for the 0.x.0 version format used by older Windows versions in client hints (0.1.0 → Windows 7, 0.2.0 → Windows 8, 0.3.0 → Windows 8.1). Also added a cleanup step to clear the version when it remains 0.0.0 after merging.
Fire OS version remap: Fixed a logic error where the version remap would fall through and incorrectly clear an already-correct Fire OS version.
OS name change on family match: When the OS family match caused a rename (e.g., Android → LeafOS), the Android platform version from client hints was incorrectly retained as the renamed OS's version. The fix uses the UA-derived version by default when a rename occurs, correctly producing no version for OSes like LeafOS that don't have their own version numbering.
Chrome OS override: When client hints report Android but the UA (after restoration) detects a Chrome OS codename, the result is correctly overridden to Chrome OS with no version.


13. Outdated Test Fixture Updates:
Several device fixture files contained OS data that predated the PHP changes being synced; these were updated to reflect current expected behavior.
Smartisan OS: 9 device entries across 4 fixture files that previously showed Android were updated to Smartisan OS with correct model-specific versions, matching the newly-added detection rules.
MRE / Java ME (feature phone): Two GIONEE device entries were corrected — one now correctly identifies as MRE 2.5.00, the other as Java ME with the Real-time OS family.
